### PR TITLE
Unify step styles for wizard

### DIFF
--- a/assets/css/step-common.css
+++ b/assets/css/step-common.css
@@ -1,0 +1,47 @@
+body {
+  background-color: #0d1117;
+  color: #e0e0e0;
+  font-family: 'Segoe UI', Roboto, sans-serif;
+}
+
+.btn-type,
+.btn-cat {
+  margin: .35rem .45rem;
+  white-space: nowrap;
+}
+
+.btn-type.active,
+.btn-cat.active {
+  background: #0d6efd !important;
+  color: #fff !important;
+}
+
+.btn-strat,
+.btn-mat {
+  margin: .25rem 0;
+  width: 100%;
+}
+
+.btn-strat.active,
+.btn-mat.active {
+  background: #198754 !important;
+  color: #fff !important;
+}
+
+.alert-custom {
+  background-color: #4c1d1d;
+  color: #f8d7da;
+  border: 1px solid #f5c2c7;
+  margin-bottom: 1.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.375rem;
+}
+
+@media (max-width: 768px) {
+  .btn-type,
+  .btn-cat,
+  .btn-strat,
+  .btn-mat {
+    width: 100%;
+  }
+}

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -192,37 +192,7 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
     rel="stylesheet"
   >
-  <style>
-    body {
-      background-color: #0d1117;
-      color: #e0e0e0;
-      font-family: 'Segoe UI', Roboto, sans-serif;
-    }
-    .btn-type {
-      margin: .35rem .45rem;
-      white-space: nowrap;
-    }
-    .btn-type.active {
-      background: #0d6efd !important;
-      color: #fff   !important;
-    }
-    .btn-strat {
-      margin: .25rem 0;
-      width: 100%;
-    }
-    .btn-strat.active {
-      background: #198754 !important;
-      color: #fff       !important;
-    }
-    .alert-custom {
-      background-color: #4c1d1d;
-      color: #f8d7da;
-      border: 1px solid #f5c2c7;
-      margin-bottom: 1.5rem;
-      padding: 0.75rem 1rem;
-      border-radius: 0.375rem;
-    }
-  </style>
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
 </head>
 <body class="container py-4">
 

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -148,16 +148,8 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
   <title>Paso 4 – Selección de madera</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
   <style>
-   body {
-  --bs-body-bg: #0d1117;
-  --bs-body-color: #e0e0e0;
-  background-color: var(--bs-body-bg);
-  color: var(--bs-body-color);
-  font-family: 'Segoe UI', Roboto, sans-serif;
-  margin: 0;
-  padding: 0;
-}
 
 /* -------------------------------
    📦 Contenedor principal
@@ -173,29 +165,6 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
 }
 
 /* -------------------------------
-   🟦 Botones por categoría
----------------------------------- */
-.btn-cat {
-  margin: 0.3rem 0.4rem;
-  white-space: nowrap;
-}
-.btn-cat.active {
-  background: #0d6efd !important;
-  color: #fff !important;
-}
-
-/* -------------------------------
-   🟩 Botones por material
----------------------------------- */
-.btn-mat {
-  margin: 0.25rem 0;
-  width: 100%;
-}
-.btn-mat.active {
-  background: #198754 !important;
-  color: #fff !important;
-}
-
 /* -------------------------------
    📋 Campos de formulario
 ---------------------------------- */
@@ -249,12 +218,6 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
 /* -------------------------------
    ⚠️ Alertas
 ---------------------------------- */
-.alert-custom {
-  background-color: #4c1d1d;
-  color: #f8d7da;
-  border: 1px solid #f5c2c7;
-  margin-bottom: 1.5rem;
-}
 .alert-warning {
   background-color: #ffd966;
   color: #664d03;


### PR DESCRIPTION
## Summary
- add shared `step-common.css` for button and alert styles
- use the new stylesheet in auto step2 and manual step4
- drop duplicate inline styles

## Testing
- `php -l views/steps/auto/step2.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68515d69f1cc832ca4e59502bf21312c