### PR TITLE
Introduce session helper

### DIFF
--- a/index.php
+++ b/index.php
@@ -37,6 +37,8 @@ if (!function_exists('dbg')) {
 }
 dbg('🔧 index.php iniciado');
 
+require_once __DIR__ . '/src/Utils/Session.php';
+
 // -------------------------------------------
 // [B] CABECERAS DE SEGURIDAD HTTP
 // -------------------------------------------
@@ -51,39 +53,11 @@ header('Permissions-Policy: geolocation=(), microphone=()');
 // -------------------------------------------
 // [C] INICIO DE SESIÓN SEGURA
 // -------------------------------------------
-if (session_status() !== PHP_SESSION_ACTIVE) {
-    session_set_cookie_params([
-        'lifetime' => 0,
-        'path'     => '/',
-        'domain'   => '',        // Ajustar dominio si es necesario
-        'secure'   => true,
-        'httponly' => true,
-        'samesite' => 'Strict'
-    ]);
-    session_start();
-    dbg('🔒 Sesión iniciada de forma segura');
-}
+startSecureSession();
 
 // -------------------------------------------
 // [D] FUNCIONES CSRF
 // -------------------------------------------
-if (!function_exists('generateCsrfToken')) {
-    function generateCsrfToken(): string {
-        if (empty($_SESSION['csrf_token'])) {
-            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
-        }
-        return $_SESSION['csrf_token'];
-    }
-}
-
-if (!function_exists('validateCsrfToken')) {
-    function validateCsrfToken(?string $token): bool {
-        if (empty($_SESSION['csrf_token']) || !is_string($token)) {
-            return false;
-        }
-        return hash_equals($_SESSION['csrf_token'], $token);
-    }
-}
 
 // -------------------------------------------
 // [E] OVERRIDE DE ESTADO “mode” POR GET

--- a/public/load-step.php
+++ b/public/load-step.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../src/Utils/Session.php';
 /**
  * File: C:\xampp\htdocs\wizard-stepper_git\load-step.php
  * ---------------------------------------------------------------
@@ -22,17 +23,7 @@ header('Pragma: no-cache');
 // ─────────────────────────────────────────────────────────────
 // [2] SESIÓN SEGURA
 // ─────────────────────────────────────────────────────────────
-if (session_status() !== PHP_SESSION_ACTIVE) {
-    session_set_cookie_params([
-        'lifetime' => 0,
-        'path'     => '/',
-        'domain'   => '',
-        'secure'   => true,
-        'httponly' => true,
-        'samesite' => 'Strict'
-    ]);
-    session_start();
-}
+startSecureSession();
 
 // ─────────────────────────────────────────────────────────────
 // [3] DEBUG OPCIONAL

--- a/src/Controller/AutoToolRecommenderController.php
+++ b/src/Controller/AutoToolRecommenderController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 use PDO;
 use PDOException;
 use RuntimeException;
+require_once __DIR__ . '/../Utils/Session.php';
 
 /**
  * Archivo: src/Controller/AutoToolRecommenderController.php
@@ -37,15 +38,9 @@ class AutoToolRecommenderController
      */
     public static function initSession(): void
     {
+        startSecureSession();
         if (session_status() !== PHP_SESSION_ACTIVE) {
-            $ok = session_start([
-                'cookie_secure'   => true,
-                'cookie_httponly' => true,
-                'cookie_samesite' => 'Strict',
-            ]);
-            if (!$ok) {
-                throw new RuntimeException('No se pudo iniciar la sesión de forma segura.');
-            }
+            throw new RuntimeException('No se pudo iniciar la sesión de forma segura.');
         }
     }
 

--- a/src/Utils/Session.php
+++ b/src/Utils/Session.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Session utilities for secure session handling and CSRF protection.
+ */
+
+declare(strict_types=1);
+
+if (!function_exists('startSecureSession')) {
+    /**
+     * Starts PHP session with secure cookie parameters if not active.
+     */
+    function startSecureSession(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_set_cookie_params([
+                'lifetime' => 0,
+                'path'     => '/',
+                'domain'   => '',
+                'secure'   => true,
+                'httponly' => true,
+                'samesite' => 'Strict'
+            ]);
+            session_start();
+            if (function_exists('dbg')) {
+                dbg('🔒 Sesión iniciada de forma segura');
+            }
+        }
+    }
+}
+
+if (!function_exists('generateCsrfToken')) {
+    /**
+     * Generates (if needed) and returns the CSRF token stored in session.
+     */
+    function generateCsrfToken(): string
+    {
+        startSecureSession();
+        if (empty($_SESSION['csrf_token'])) {
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        }
+        return $_SESSION['csrf_token'];
+    }
+}
+
+if (!function_exists('validateCsrfToken')) {
+    /**
+     * Validates a provided CSRF token against the one in session.
+     */
+    function validateCsrfToken(?string $token): bool
+    {
+        startSecureSession();
+        if (empty($_SESSION['csrf_token']) || !is_string($token)) {
+            return false;
+        }
+        return hash_equals($_SESSION['csrf_token'], $token);
+    }
+}


### PR DESCRIPTION
## Summary
- add Session utilities for secure session start and CSRF handling
- use the helper in `index.php`, `load-step.php` and auto tool controller

## Testing
- `php -l src/Utils/Session.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685160492b24832c95fa046bb5a13a05