### PR TITLE
Read DB config from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_NAME=cnc_calculador
+DB_USER=root
+DB_PASS=


### PR DESCRIPTION
## Summary
- load DB settings from `.env` and `$_ENV`
- add helper `env()` to read vars with defaults
- provide `.env.example`

## Testing
- `php -l includes/db.php`
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_685161112fb0832c8d7c62446b277bdc