### PR TITLE
Remove back buttons and unify next button

### DIFF
--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -325,12 +325,14 @@ dbg('children', $children);
     </div>
 
     <!-- 5) Botón “Siguiente” -->
-    <button
-      type="submit"
-      id="nextBtn"
-      class="btn btn-primary"
-      disabled
-    >Siguiente → Paso 2</button>
+    <div class="mt-4 text-end">
+      <button
+        type="submit"
+        id="nextBtn"
+        class="btn btn-primary btn-lg float-end"
+        disabled
+      >Siguiente →</button>
+    </div>
   </form>
 
   <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -249,11 +249,13 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
     </div>
 
     <!-- 3) Botón “Siguiente” -->
-    <button
-      id="nextBtn_p2"
-      class="btn btn-primary"
-      <?= $hasPrev ? '' : 'disabled' ?>
-    >Siguiente → Paso 3</button>
+    <div class="mt-4 text-end">
+      <button
+        id="nextBtn_p2"
+        class="btn btn-primary btn-lg float-end"
+        <?= $hasPrev ? '' : 'disabled' ?>
+      >Siguiente →</button>
+    </div>
   </form>
 
   <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -369,9 +369,7 @@ if (isset($tool['length_total_mm'])) {
       <i class="bi bi-exclamation-triangle"></i>
       <?= htmlspecialchars($error, ENT_QUOTES) ?>
     </div>
-    <a href="step3.php" class="btn-back mt-3">
-      <i class="bi bi-arrow-left-circle"></i> Volver a Paso 3
-    </a>
+      <!-- Botón de retroceso eliminado -->
 
   <?php else: ?>
     <div class="card mb-4">
@@ -412,18 +410,15 @@ if (isset($tool['length_total_mm'])) {
     </div>
 
     <!-- Formulario para avanzar a Paso 5 -->
-    <form action="step5.php" method="post" class="d-flex justify-content-between">
+      <form action="step5.php" method="post" class="mt-4 text-end">
       <input type="hidden" name="step"       value="4">
       <input type="hidden" name="tool_id"    value="<?= htmlspecialchars((string)$tool['tool_id'], ENT_QUOTES) ?>">
       <input type="hidden" name="tool_table" value="<?= htmlspecialchars((string)$_SESSION['tool_table'], ENT_QUOTES) ?>">
 
-      <a href="step3.php" class="btn-back">
-        ← Volver a Paso 3
-      </a>
-      <button type="submit" class="btn-next">
-        Siguiente → Paso 5
-      </button>
-    </form>
+        <button type="submit" class="btn btn-primary btn-lg float-end">
+          Siguiente →
+        </button>
+      </form>
   <?php endif; ?>
 </main>
 

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -223,14 +223,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </div>
       <?php endif; ?>
 
-      <div class="mt-3 text-end">
-        <button id="nextBtn"
-                class="btn btn-primary"
-                type="submit"
-                disabled>
-          Siguiente <i class="bi bi-arrow-right-circle"></i>
-        </button>
-      </div>
+
     </div>
   </form>
 
@@ -288,8 +281,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         document.getElementById('tool_id').value    = btn.dataset.tool_id;
         document.getElementById('tool_table').value = btn.dataset.tbl;
 
-        // Activamos el botón “Siguiente” y forzamos el submit
-        document.getElementById('nextBtn').disabled = false;
+        // Enviamos el formulario automáticamente luego de la selección
         document.getElementById('step1ManualForm').requestSubmit();
 
         dbg('► herramienta seleccionada:', btn.dataset.tbl, btn.dataset.tool_id);

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -124,9 +124,7 @@ if ($tool) {
       <div class="alert alert-danger mt-3">
         <i class="bi bi-exclamation-triangle"></i> <?= htmlspecialchars($error) ?>
       </div>
-      <a href="step1.php" class="btn btn-outline-light mt-3">
-        <i class="bi bi-arrow-left-circle"></i> Volver a seleccionar
-      </a>
+      <!-- Botón eliminado por nuevo flujo sin regreso -->
 
   <?php else: ?>
       <div class="card bg-dark text-white mt-3">
@@ -150,19 +148,16 @@ if ($tool) {
       </div>
 
       <!-- ********  ¡campo step=2 añadido!  ******** -->
-      <form action="step4_select_strategy.php"
-            method="post"
-            class="d-flex justify-content-between mt-4">
+        <form action="step4_select_strategy.php"
+              method="post"
+              class="mt-4 text-end">
         <input type="hidden" name="step"       value="2">
         <input type="hidden" name="tool_id"    value="<?= $tool['tool_id'] ?>">
         <input type="hidden" name="tool_table" value="<?= htmlspecialchars($_SESSION['tool_table']) ?>">
 
-        <a href="step1.php" class="btn btn-outline-secondary">
-          <i class="bi bi-arrow-left-circle"></i> Volver
-        </a>
-        <button type="submit" class="btn btn-primary">
-          Siguiente <i class="bi bi-arrow-right-circle"></i>
-        </button>
+          <button type="submit" class="btn btn-primary btn-lg float-end">
+            Siguiente →
+          </button>
       </form>
   <?php endif; ?>
 </main>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -309,9 +309,11 @@ dbg('Tipos de mecanizado disponibles:', $grouped);
     </div>
 
     <!-- 3) Continuar -->
-    <button type="submit" class="btn btn-primary" id="btn-next" disabled>
-      Siguiente → Paso 4
-    </button>
+    <div class="mt-4 text-end">
+      <button type="submit" class="btn btn-primary btn-lg float-end" id="btn-next" disabled>
+        Siguiente →
+      </button>
+    </div>
   </form>
 
   <!-- Caja de debug interno -->

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -368,16 +368,13 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
         >
       </div>
 
-      <!-- 5) Botones “Volver” y “Siguiente” -->
-      <div class="d-flex align-items-center">
-        <a href="step3.php" class="btn btn-back">
-          ← Volver al Paso 3
-        </a>
+      <!-- 5) Botón “Siguiente” unificado -->
+      <div class="mt-4 text-end">
         <button type="submit"
-                class="btn btn-next ms-auto"
+                class="btn btn-primary btn-lg float-end"
                 id="btnNext"
                 <?= (empty($data) || !($hasPrevMat && $hasPrevThick)) ? 'disabled' : '' ?>>
-          Siguiente → Paso 5
+          Siguiente →
         </button>
       </div>
     </form>

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -282,13 +282,15 @@ $hasPrev = is_int($prev['transmission_id']) && $prev['transmission_id'] > 0;
       </div>
 
       <!-- 3) Botón “Siguiente” -->
-      <button
-        id="nextBtn"
-        class="btn btn-primary"
-        <?= $hasPrev ? '' : 'disabled' ?>
-      >
-        Siguiente → Paso 6
-      </button>
+      <div class="mt-4 text-end">
+        <button
+          id="nextBtn"
+          class="btn btn-primary btn-lg float-end"
+          <?= $hasPrev ? '' : 'disabled' ?>
+        >
+          Siguiente →
+        </button>
+      </div>
     </form>
   </div>
 


### PR DESCRIPTION
## Summary
- delete Step 1 manual navigation button and script reference
- strip back links from other steps
- standardise "Siguiente →" buttons across wizard steps

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516afb741c832cbea56159b1ab041e