### PR TITLE
Create shared next button component

### DIFF
--- a/views/components/button-next.php
+++ b/views/components/button-next.php
@@ -1,0 +1,5 @@
+<div class="text-end mt-4">
+  <button type="submit" class="btn btn-primary btn-lg float-end mt-4 btn-next-step">
+    Siguiente →
+  </button>
+</div>

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -325,14 +325,7 @@ dbg('children', $children);
     </div>
 
     <!-- 5) Botón “Siguiente” -->
-    <div class="text-end mt-4">
-      <button type="submit"
-              class="btn btn-primary btn-lg float-end mt-4 btn-next-step"
-              id="nextBtn"
-              disabled>
-        Siguiente →
-      </button>
-    </div>
+    <?php include __DIR__ . "/../../components/button-next.php"; ?>
   </form>
 
   <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -248,15 +248,7 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
       </div>
     </div>
 
-    <!-- 3) Botón “Siguiente” -->
-    <div class="text-end mt-4">
-      <button type="submit"
-              class="btn btn-primary btn-lg float-end mt-4 btn-next-step"
-              id="nextBtn_p2"
-              <?= $hasPrev ? '' : 'disabled' ?>>
-        Siguiente →
-      </button>
-    </div>
+    <?php include __DIR__ . "/../../components/button-next.php"; ?>
   </form>
 
   <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -403,11 +403,7 @@ if (isset($tool['length_total_mm'])) {
       <input type="hidden" name="tool_id"    value="<?= htmlspecialchars((string)$tool['tool_id'], ENT_QUOTES) ?>">
       <input type="hidden" name="tool_table" value="<?= htmlspecialchars((string)$_SESSION['tool_table'], ENT_QUOTES) ?>">
 
-        <div class="text-end mt-4">
-          <button type="submit" class="btn btn-primary btn-lg float-end mt-4 btn-next-step">
-            Siguiente →
-          </button>
-        </div>
+        <?php include __DIR__ . "/../../components/button-next.php"; ?>
       </form>
   <?php endif; ?>
 </main>

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -154,11 +154,7 @@ if ($tool) {
         <input type="hidden" name="step"       value="2">
         <input type="hidden" name="tool_id"    value="<?= $tool['tool_id'] ?>">
         <input type="hidden" name="tool_table" value="<?= htmlspecialchars($_SESSION['tool_table']) ?>">
-          <div class="text-end mt-4">
-            <button type="submit" class="btn btn-primary btn-lg float-end mt-4 btn-next-step">
-              Siguiente →
-            </button>
-          </div>
+          <?php include __DIR__ . "/../../components/button-next.php"; ?>
       </form>
   <?php endif; ?>
 </main>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -309,13 +309,7 @@ dbg('Tipos de mecanizado disponibles:', $grouped);
     </div>
 
     <!-- 3) Continuar -->
-    <div class="text-end mt-4">
-      <button type="submit"
-              class="btn btn-primary btn-lg float-end mt-4 btn-next-step"
-              id="btn-next" disabled>
-        Siguiente →
-      </button>
-    </div>
+    <?php include __DIR__ . "/../../components/button-next.php"; ?>
   </form>
 
   <!-- Caja de debug interno -->

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -354,14 +354,7 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
       </div>
 
       <!-- 5) Botón “Siguiente” unificado -->
-      <div class="text-end mt-4">
-        <button type="submit"
-                class="btn btn-primary btn-lg float-end mt-4 btn-next-step"
-                id="btnNext"
-                <?= (empty($data) || !($hasPrevMat && $hasPrevThick)) ? 'disabled' : '' ?>>
-          Siguiente →
-        </button>
-      </div>
+<?php include __DIR__ . "/../../components/button-next.php"; ?>
     </form>
   </div>
 

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -270,14 +270,7 @@ $hasPrev = is_int($prev['transmission_id']) && $prev['transmission_id'] > 0;
       </div>
 
       <!-- 3) Botón “Siguiente” -->
-      <div class="text-end mt-4">
-        <button type="submit"
-                class="btn btn-primary btn-lg float-end mt-4 btn-next-step"
-                id="nextBtn"
-                <?= $hasPrev ? '' : 'disabled' ?>>
-          Siguiente →
-        </button>
-      </div>
+<?php include __DIR__ . "/../components/button-next.php"; ?>
     </form>
   </div>
 


### PR DESCRIPTION
## Summary
- add `views/components` folder with reusable next button markup
- replace hardcoded button HTML in step views with includes

## Testing
- `grep -R "button-next.php" views/steps | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_685179ab1e44832c95e87ac7753667d6