### PR TITLE
Standardize wizard step layouts

### DIFF
--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -259,7 +259,8 @@ dbg('children', $children);
     }
   </style>
 </head>
-<body class="container py-4">
+<body>
+  <div class="container py-4">
 
   <h2 class="mb-3">Paso 1 – Elegí el material y el espesor</h2>
 
@@ -327,7 +328,7 @@ dbg('children', $children);
     <!-- 5) Botón “Siguiente” -->
     <div class="text-end mt-4">
       <button type="submit"
-              class="btn btn-primary btn-lg float-end mt-4 btn-next-step"
+              class="btn btn-primary btn-lg"
               id="nextBtn"
               disabled>
         Siguiente →
@@ -541,5 +542,6 @@ dbg('children', $children);
     }
   });
   </script>
+  </div>
 </body>
 </html>

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -194,7 +194,8 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
   >
   <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
 </head>
-<body class="container py-4">
+<body>
+  <div class="container py-4">
 
   <h2 class="mb-3">Paso 2 – Seleccioná mecanizado y estrategia</h2>
 
@@ -251,7 +252,7 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
     <!-- 3) Botón “Siguiente” -->
     <div class="text-end mt-4">
       <button type="submit"
-              class="btn btn-primary btn-lg float-end mt-4 btn-next-step"
+              class="btn btn-primary btn-lg"
               id="nextBtn_p2"
               <?= $hasPrev ? '' : 'disabled' ?>>
         Siguiente →
@@ -315,5 +316,6 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
     }
   })();
   </script>
+  </div>
 </body>
 </html>

--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -188,7 +188,8 @@ try {
     }
   </style>
 </head>
-<body class="container py-4">
+<body>
+  <div class="container py-4">
 
   <h2>Paso 3 – Herramientas compatibles (Modo Auto)</h2>
 
@@ -212,6 +213,12 @@ try {
     <input type="hidden" id="tool_id"    name="tool_id"    value="">
     <input type="hidden" id="tool_table" name="tool_table" value="">
   </form>
+
+  <div class="text-end mt-4">
+    <button type="submit" form="selectForm" class="btn btn-primary btn-lg" id="btn-next" disabled>
+      Siguiente →
+    </button>
+  </div>
 
   <!-- 7.4) Consola interna de debugging -->
   <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>
@@ -417,5 +424,6 @@ try {
     fetchTools();
   })();
   </script>
+  </div>
 </body>
 </html>

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -346,7 +346,7 @@ if (isset($tool['length_total_mm'])) {
 </head>
 <body>
 
-<main class="wizard-body">
+<div class="container py-4">
   <div class="wizard-header">
     <i class="bi bi-tools"></i>
     <h2>Paso 4 – Confirmar herramienta</h2>
@@ -404,13 +404,13 @@ if (isset($tool['length_total_mm'])) {
       <input type="hidden" name="tool_table" value="<?= htmlspecialchars((string)$_SESSION['tool_table'], ENT_QUOTES) ?>">
 
         <div class="text-end mt-4">
-          <button type="submit" class="btn btn-primary btn-lg float-end mt-4 btn-next-step">
+          <button type="submit" class="btn btn-primary btn-lg">
             Siguiente →
           </button>
         </div>
       </form>
   <?php endif; ?>
-</main>
+</div>
 
 <pre id="debug"></pre>
 </body>

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -151,7 +151,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <input type="hidden" name="tool_id"     id="tool_id" value="">
     <input type="hidden" name="tool_table"  id="tool_table" value="">
 
-    <div class="container-fluid py-4" data-debug="step1">
+    <div class="container py-4" data-debug="step1">
       <div class="d-flex justify-content-between align-items-center mb-4">
         <h2 class="fw-bold text-white m-0">
           <i class="bi bi-box-seam"></i> Explorador de fresas
@@ -223,6 +223,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </div>
       <?php endif; ?>
 
+
+      <div class="text-end mt-4">
+        <button type="submit" class="btn btn-primary btn-lg">
+          Siguiente →
+        </button>
+      </div>
 
     </div>
   </form>

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -117,7 +117,7 @@ if ($tool) {
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
 <link rel="stylesheet" href="assets/css/step2_manual.css">
 
-<main class="wizard-body shadow-lg mt-4">
+<div class="container py-4">
   <h2 class="text-info"><i class="bi bi-tools"></i> Confirmar herramienta</h2>
 
   <?php if ($error): ?>
@@ -155,13 +155,13 @@ if ($tool) {
         <input type="hidden" name="tool_id"    value="<?= $tool['tool_id'] ?>">
         <input type="hidden" name="tool_table" value="<?= htmlspecialchars($_SESSION['tool_table']) ?>">
           <div class="text-end mt-4">
-            <button type="submit" class="btn btn-primary btn-lg float-end mt-4 btn-next-step">
+            <button type="submit" class="btn btn-primary btn-lg">
               Siguiente →
             </button>
           </div>
       </form>
   <?php endif; ?>
-</main>
+</div>
 
 <!-- consola interna -->
 <pre id="debug" class="debug-box"></pre>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -272,7 +272,8 @@ dbg('Tipos de mecanizado disponibles:', $grouped);
     }
   </style>
 </head>
-<body class="container py-4">
+<body>
+  <div class="container py-4">
 
   <h2 class="mb-4">Paso 3 – Elegí el tipo de mecanizado y la estrategia</h2>
 
@@ -311,7 +312,7 @@ dbg('Tipos de mecanizado disponibles:', $grouped);
     <!-- 3) Continuar -->
     <div class="text-end mt-4">
       <button type="submit"
-              class="btn btn-primary btn-lg float-end mt-4 btn-next-step"
+              class="btn btn-primary btn-lg"
               id="btn-next" disabled>
         Siguiente →
       </button>
@@ -395,5 +396,6 @@ dbg('Tipos de mecanizado disponibles:', $grouped);
       btnNext.disabled = true;
     });
   </script>
+  </div>
 </body>
 </html>

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -279,7 +279,7 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
 </head>
 <body>
 
-  <div class="wizard-body">
+  <div class="container py-4">
     <h2>Paso 4 – Elegí la madera compatible</h2>
 
     <!-- Si no se encontró ninguna madera compatible, mostrar alerta -->
@@ -356,7 +356,7 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
       <!-- 5) Botón “Siguiente” unificado -->
       <div class="text-end mt-4">
         <button type="submit"
-                class="btn btn-primary btn-lg float-end mt-4 btn-next-step"
+                class="btn btn-primary btn-lg"
                 id="btnNext"
                 <?= (empty($data) || !($hasPrevMat && $hasPrevThick)) ? 'disabled' : '' ?>>
           Siguiente →

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -190,8 +190,8 @@ $hasPrev = is_int($prev['transmission_id']) && $prev['transmission_id'] > 0;
     }
   </style>
 </head>
-<body class="py-4">
-  <div class="container">
+<body>
+  <div class="container py-4">
     <h2>Paso 5 – Configurá tu router</h2>
 
     <?php if (!empty($errors)): ?>
@@ -272,7 +272,7 @@ $hasPrev = is_int($prev['transmission_id']) && $prev['transmission_id'] > 0;
       <!-- 3) Botón “Siguiente” -->
       <div class="text-end mt-4">
         <button type="submit"
-                class="btn btn-primary btn-lg float-end mt-4 btn-next-step"
+                class="btn btn-primary btn-lg"
                 id="nextBtn"
                 <?= $hasPrev ? '' : 'disabled' ?>>
           Siguiente →
@@ -336,5 +336,6 @@ $hasPrev = is_int($prev['transmission_id']) && $prev['transmission_id'] > 0;
     <?php endif; ?>
   })();
   </script>
+  </div>
 </body>
 </html>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -237,6 +237,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
   
 </head>
 <body>
+  <div class="container py-4">
 <?php endif; ?>
 
 <!-- ALERTA DE ASSETS FALTANTES -->
@@ -629,6 +630,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js"></script>
 <script src="/wizard-stepper_git/assets/js/step6.js"></script>
+  </div>
 
 <?php if (!$embedded): ?>
 </body>


### PR DESCRIPTION
## Summary
- unify main container across step views
- standardize `Siguiente` buttons
- remove unused button classes
- wrap final results step in container

## Testing
- `php -l` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68517d0f6258832cb075d3c7909d2911