### PR TITLE
Add ToolService helper and use it in AJAX

### DIFF
--- a/ajax/tools_ajax.php
+++ b/ajax/tools_ajax.php
@@ -1,6 +1,7 @@
 <?php
 // tools_ajax.php - Devuelve lista de herramientas filtradas (sin autenticación)
 require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../src/Utils/ToolService.php';
 header('Content-Type: application/json; charset=utf-8');
 
 $brandTables = [
@@ -129,6 +130,11 @@ foreach ($stmt as $row) {
     $det = $pdo->prepare("SELECT * FROM {$row['tbl']} WHERE tool_id=?");
     $det->execute([$row['tool_id']]);
     $row['details'] = $det->fetch(PDO::FETCH_ASSOC);
+    $row['details']['image_url'] = ToolService::getToolImageUrl(
+        $pdo,
+        $row['tbl'],
+        (int) $row['tool_id']
+    );
 
     // Fetch parameters per material
     $tm = 'toolsmaterial_' . substr($row['tbl'], 6);

--- a/src/Utils/ToolService.php
+++ b/src/Utils/ToolService.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+class ToolService
+{
+    /**
+     * Returns the full URL of a tool image, caching the value in session.
+     * If the tool has no image or an error occurs, returns an empty string.
+     */
+    public static function getToolImageUrl(PDO $pdo, string $table, int $toolId): string
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        if ($toolId <= 0 || !preg_match('/^[a-z0-9_]+$/i', $table)) {
+            return '';
+        }
+
+        if (!isset($_SESSION['tool_images'])) {
+            $_SESSION['tool_images'] = [];
+        }
+
+        if (isset($_SESSION['tool_images'][$table][$toolId])) {
+            return (string)$_SESSION['tool_images'][$table][$toolId];
+        }
+
+        $sql = "SELECT image FROM {$table} WHERE tool_id = ? LIMIT 1";
+        $stmt = $pdo->prepare($sql);
+        if ($stmt === false) {
+            return '';
+        }
+
+        try {
+            $stmt->execute([$toolId]);
+            $img = $stmt->fetchColumn();
+        } catch (\PDOException $e) {
+            return '';
+        }
+
+        if (!$img) {
+            $_SESSION['tool_images'][$table][$toolId] = '';
+            return '';
+        }
+
+        $path = '/wizard-stepper_git/' . ltrim((string)$img, "\\/");
+        $_SESSION['tool_images'][$table][$toolId] = $path;
+        return $path;
+    }
+}


### PR DESCRIPTION
## Summary
- add ToolService with session based caching of tool image URLs
- use ToolService in `tools_ajax.php`

## Testing
- `php -l src/Utils/ToolService.php`
- `php -l ajax/tools_ajax.php`
- `find src -name '*.php' | xargs -I{} php -l {}`
- `composer validate --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_68517dcb3b10832ca35b3548e82280b2