### PR TITLE
Dynamically reveal Next buttons

### DIFF
--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -326,11 +326,8 @@ dbg('children', $children);
     </div>
 
     <!-- 5) Botón “Siguiente” -->
-    <div class="text-end mt-4">
-      <button type="submit"
-              class="btn btn-primary btn-lg"
-              id="nextBtn"
-              disabled>
+    <div id="next-button-container" class="text-end mt-4" style="display: none;">
+      <button type="submit" id="btn-next" class="btn btn-primary btn-lg">
         Siguiente →
       </button>
     </div>
@@ -360,7 +357,8 @@ dbg('children', $children);
   const matInp   = document.getElementById('material_id');
   const thick    = document.getElementById('thick');
   const thickGrp = document.getElementById('thickGroup');
-  const nextBtn  = document.getElementById('nextBtn');
+  const nextContainer = document.getElementById('next-button-container');
+  const nextBtn  = document.getElementById('btn-next');
   const search   = document.getElementById('matSearch');
   const noMatch  = document.getElementById('noMatchMsg');
   const dropdown = document.getElementById('searchDropdown');
@@ -382,16 +380,16 @@ dbg('children', $children);
     matInp.value = '';
     thickGrp.style.display = 'none';
     thick.value = '';
-    nextBtn.disabled = true;
+    nextContainer.style.display = 'none';
     search.classList.remove('is-invalid');
     noMatch.style.display = 'none';
   }
 
   function validate() {
     if (matInp.value && parseFloat(thick.value) > 0) {
-      nextBtn.disabled = false;
+      nextContainer.style.display = 'block';
     } else {
-      nextBtn.disabled = true;
+      nextContainer.style.display = 'none';
     }
   }
 

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -250,11 +250,8 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
     </div>
 
     <!-- 3) Botón “Siguiente” -->
-    <div class="text-end mt-4">
-      <button type="submit"
-              class="btn btn-primary btn-lg"
-              id="nextBtn_p2"
-              <?= $hasPrev ? '' : 'disabled' ?>>
+    <div id="next-button-container" class="text-end mt-4" style="display: <?= $hasPrev ? 'block' : 'none' ?>;">
+      <button type="submit" id="btn-next" class="btn btn-primary btn-lg">
         Siguiente →
       </button>
     </div>
@@ -273,13 +270,14 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
     const stratCol = document.getElementById('stratCol');
     const inType   = document.getElementById('machining_type_id');
     const inStrat  = document.getElementById('strategy_id');
-    const nextBtn  = document.getElementById('nextBtn_p2');
+    const nextContainer = document.getElementById('next-button-container');
+    const nextBtn  = document.getElementById('btn-next');
 
     function resetStrat() {
       stratCol.innerHTML = '';
       stratBox.style.display = 'none';
       inStrat.value = '';
-      nextBtn.disabled = true;
+      nextContainer.style.display = 'none';
     }
 
     // Clic en tipo de mecanizado
@@ -302,7 +300,7 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
             stratCol.querySelectorAll('.btn-strat').forEach(x => x.classList.remove('active'));
             b.classList.add('active');
             inStrat.value = s.id;
-            nextBtn.disabled = false;
+            nextContainer.style.display = 'block';
           });
           stratCol.appendChild(b);
         });
@@ -313,6 +311,9 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
     // Si había valores previos, mostrar estrategias
     if (inType.value) {
       stratBox.style.display = 'block';
+    }
+    if (inType.value && inStrat.value) {
+      nextContainer.style.display = 'block';
     }
   })();
   </script>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -310,10 +310,8 @@ dbg('Tipos de mecanizado disponibles:', $grouped);
     </div>
 
     <!-- 3) Continuar -->
-    <div class="text-end mt-4">
-      <button type="submit"
-              class="btn btn-primary btn-lg"
-              id="btn-next" disabled>
+    <div id="next-button-container" class="text-end mt-4" style="display: none;">
+      <button type="submit" id="btn-next" class="btn btn-primary btn-lg">
         Siguiente →
       </button>
     </div>
@@ -329,6 +327,7 @@ dbg('Tipos de mecanizado disponibles:', $grouped);
   <script>
     // Convertir “$grouped” de PHP a objeto JS
     const grouped = <?= json_encode($grouped, JSON_UNESCAPED_UNICODE) ?>;
+    const nextContainer = document.getElementById('next-button-container');
     const btnNext   = document.getElementById('btn-next');
     const inputType = document.getElementById('machining_type_id');
     const inputStrat= document.getElementById('strategy_id');
@@ -367,13 +366,13 @@ dbg('Tipos de mecanizado disponibles:', $grouped);
                     .forEach(bs => bs.classList.remove('active'));
             b.classList.add('active');
             inputStrat.value = e.id;
-            btnNext.disabled = false;
+            nextContainer.style.display = 'block';
             dbg('Estrategia seleccionada:', e.id, e.name);
           });
           strategyBtns.appendChild(b);
         });
         strategyBox.style.display = 'block';
-        btnNext.disabled = true;
+        nextContainer.style.display = 'none';
         dbg('Tipo de mecanizado seleccionado:', mtid, grouped[mtid].name);
       });
     });
@@ -393,7 +392,7 @@ dbg('Tipos de mecanizado disponibles:', $grouped);
 
     // 3) Evitar doble envío muy rápido
     form.addEventListener('submit', () => {
-      btnNext.disabled = true;
+      nextContainer.style.display = 'none';
     });
   </script>
   </div>

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -354,11 +354,8 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
       </div>
 
       <!-- 5) Botón “Siguiente” unificado -->
-      <div class="text-end mt-4">
-        <button type="submit"
-                class="btn btn-primary btn-lg"
-                id="btnNext"
-                <?= (empty($data) || !($hasPrevMat && $hasPrevThick)) ? 'disabled' : '' ?>>
+      <div id="next-button-container" class="text-end mt-4" style="display: <?= ($hasPrevMat && $hasPrevThick) ? 'block' : 'none' ?>;">
+        <button type="submit" id="btn-next" class="btn btn-primary btn-lg">
           Siguiente →
         </button>
       </div>
@@ -388,7 +385,8 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
   const matCol  = document.getElementById('matCol');
   const matBox  = document.getElementById('matBox');
   const thickIn = document.getElementById('thick');
-  const nextBtn = document.getElementById('btnNext');
+  const nextContainer = document.getElementById('next-button-container');
+  const nextBtn = document.getElementById('btn-next');
   const search  = document.getElementById('matSearch');
   const noMatch = document.getElementById('noMatchMsg');
   const dropdown = document.getElementById('searchDropdown');
@@ -412,7 +410,7 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
     hiddenMat.value = '';
     thickIn.value = '';
     thickIn.parentNode.style.display = 'none';
-    nextBtn.disabled = true;
+    nextContainer.style.display = 'none';
     search.classList.remove('is-invalid');
     noMatch.style.display = 'none';
     hideDropdown();
@@ -421,7 +419,7 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
   function validateNext() {
     const matOk   = hiddenMat.value !== '';
     const thickOk = parseFloat(thickIn.value) > 0;
-    nextBtn.disabled = !(matOk && thickOk);
+    nextContainer.style.display = (matOk && thickOk) ? 'block' : 'none';
   }
 
   function noMatchMsg(state) {

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -270,11 +270,8 @@ $hasPrev = is_int($prev['transmission_id']) && $prev['transmission_id'] > 0;
       </div>
 
       <!-- 3) Botón “Siguiente” -->
-      <div class="text-end mt-4">
-        <button type="submit"
-                class="btn btn-primary btn-lg"
-                id="nextBtn"
-                <?= $hasPrev ? '' : 'disabled' ?>>
+      <div id="next-button-container" class="text-end mt-4" style="display: <?= $hasPrev ? 'block' : 'none' ?>;">
+        <button type="submit" id="btn-next" class="btn btn-primary btn-lg">
           Siguiente →
         </button>
       </div>
@@ -285,7 +282,8 @@ $hasPrev = is_int($prev['transmission_id']) && $prev['transmission_id'] > 0;
   (function() {
     const radios    = document.querySelectorAll('.btn-check');
     const paramSection = document.getElementById('paramSection');
-    const nextBtn   = document.getElementById('nextBtn');
+    const nextContainer = document.getElementById('next-button-container');
+    const nextBtn   = document.getElementById('btn-next');
     const getById   = id => document.getElementById(id);
     const inputs    = {
       rpm_min:  getById('rpm_min'),
@@ -297,7 +295,7 @@ $hasPrev = is_int($prev['transmission_id']) && $prev['transmission_id'] > 0;
     // Ocultar inputs hasta que se elija una transmisión
     function hideParams() {
       paramSection.style.display = 'none';
-      nextBtn.disabled = true;
+      nextContainer.style.display = 'none';
       for (const key in inputs) {
         inputs[key].value = '';
         inputs[key].disabled = true;
@@ -326,7 +324,7 @@ $hasPrev = is_int($prev['transmission_id']) && $prev['transmission_id'] > 0;
         for (const key in inputs) {
           inputs[key].disabled = false;
         }
-        nextBtn.disabled = false;
+        nextContainer.style.display = 'block';
       });
     });
 


### PR DESCRIPTION
## Summary
- hide Next button containers until the step is valid
- show the button after selecting required options or filling inputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685184cc9704832ca4ca149ab68e059e