### PR TITLE
Fix visibility of Next button on manual step4

### DIFF
--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -357,7 +357,7 @@ $hasPrevThick = is_numeric($prevThick) && $prevThick > 0;
       </div>
 
       <!-- 5) Botón “Siguiente” unificado -->
-      <div id="next-button-container" class="text-end mt-4" style="display: <?= ($hasPrevMat && $hasPrevThick) ? 'block' : 'none' ?>;">
+      <div id="next-button-container" class="text-end mt-4" style="display: none;">
         <button type="submit" id="btn-next" class="btn btn-primary btn-lg">
           Siguiente →
         </button>


### PR DESCRIPTION
## Summary
- hide "Siguiente" button on load for manual step 4
- rely on JavaScript to toggle the button when fields are filled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851a1a62d98832c9ae6d56beadd941c