### PR TITLE
Remove next button from manual step1

### DIFF
--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -207,13 +207,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </div>
       <?php endif; ?>
 
-
-      <div class="text-end mt-4">
-        <button type="submit" class="btn btn-primary btn-lg">
-          Siguiente →
-        </button>
-      </div>
-
     </main>
   </form>
 


### PR DESCRIPTION
## Summary
- remove the "Siguiente" button from manual step 1

## Testing
- `grep -n "Siguiente" -n views/steps/manual/step1.php`

------
https://chatgpt.com/codex/tasks/task_e_6851c6401040832c8207b02200139d84