### PR TITLE
Persist tool image between steps

### DIFF
--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -92,6 +92,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (empty($errors)) {
         $_SESSION['tool_id']    = $toolId;
         $_SESSION['tool_table'] = $toolTable;
+
+        // Guardar también la URL de la imagen seleccionada para usarla en el Paso 2
+        require_once __DIR__ . '/../../../src/Utils/ToolService.php';
+        $imgUrl = ToolService::getToolImageUrl($pdo, $toolTable, $toolId);
+        $_SESSION['tool_image_url'] = $imgUrl;
+
         $_SESSION['wizard_progress'] = 2; // Marcamos que ya completó Paso 1
         dbg('Paso 1 validado con éxito. tool_id=', $toolId, 'tool_table=', $toolTable);
 

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -111,7 +111,9 @@ dbg('STEP-2', $error ? ['ERR'=>$error] : ['OK'=>$tool['tool_id']??'-']);
 /* ---------- fallback longitud total -------------------------------------- */
 if ($tool) {
     $tool['length_total_mm'] ??= $tool['full_length_mm'] ?? 0;
-    if (!empty($tool['image'])) {
+    if (!empty($_SESSION['tool_image_url'])) {
+        $tool['image_url'] = rtrim((string)$_SESSION['tool_image_url'], '/');
+    } elseif (!empty($tool['image'])) {
         $tool['image_url'] = '/wizard-stepper_git/' . ltrim((string)$tool['image'], '/');
     }
 }
@@ -133,7 +135,7 @@ if ($tool) {
       <?php if (!empty($tool['image_url'])): ?>
         <figure class="text-center mb-4">
           <img
-            src="/<?= htmlspecialchars($tool['image_url']) ?>"
+            src="<?= htmlspecialchars($tool['image_url']) ?>"
             alt="Imagen de la herramienta seleccionada"
             class="img-fluid rounded shadow-sm"
             style="max-width: 100%; height: auto;"


### PR DESCRIPTION
## Summary
- keep image URL from step 1 to reuse in step 2
- avoid double slashes in preview

## Testing
- `php -l views/steps/manual/step1.php`
- `php -l views/steps/manual/step2.php`


------
https://chatgpt.com/codex/tasks/task_e_6852020fc0a4832c884e1c91d8018e7d