### PR TITLE
Refactor CSS structure

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+assets/css/bootstrap.min.css

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}

--- a/assets/css/base/layout.css
+++ b/assets/css/base/layout.css
@@ -1,0 +1,27 @@
+/* Utility helpers */
+.flex {
+  display: flex;
+}
+
+.flex-column {
+  flex-direction: column;
+}
+
+.gap-1 {
+  gap: var(--spacer-1);
+}
+
+.gap-2 {
+  gap: var(--spacer-2);
+}
+
+.text-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shadow-sm {
+  box-shadow: 0 0 4px rgb(0 0 0 / 10%);
+}
+

--- a/assets/css/base/theme.css
+++ b/assets/css/base/theme.css
@@ -1,0 +1,17 @@
+body {
+  background-color: var(--color-bg-dark);
+  color: var(--color-text);
+  font-family: 'Segoe UI', Roboto, sans-serif;
+}
+
+.btn-primary {
+  background-color: var(--color-accent);
+  border-color: var(--color-border);
+  color: #fff;
+  transition: .15s;
+}
+
+.btn-primary:hover {
+  background-color: #3aa5cc;
+}
+

--- a/assets/css/base/variables.css
+++ b/assets/css/base/variables.css
@@ -1,0 +1,12 @@
+:root {
+  --color-bg-dark: #0d1117;
+  --color-text: #e0e0e0;
+  --color-accent: #4fc3f7;
+  --color-border: #2c2f33;
+  --color-bg-darker: #0f172a;
+  --color-bg-alt: #1e293b;
+  --radius-lg: 0.75rem;
+  --spacer-1: 0.5rem;
+  --spacer-2: 1rem;
+}
+

--- a/assets/css/components/dropdown-search.css
+++ b/assets/css/components/dropdown-search.css
@@ -1,0 +1,35 @@
+/* dropdown-search component */
+.dropdown-search {
+  position: absolute;
+  width: 100%;
+  max-height: 200px;
+  overflow-y: auto;
+  background: #000;
+  border: 1px solid #444;
+  z-index: 1000;
+  display: none;
+}
+
+.dropdown-search .item {
+  padding: .5rem .75rem;
+  color: #f1f1f1;
+  cursor: pointer;
+}
+
+.dropdown-search .item:hover {
+  background: #333;
+}
+
+.dropdown-search .hl {
+  background: #ffd54f;
+  color: #000;
+}
+
+/* deduplicado de /assets/css/material.css y /assets/css/strategy.css */
+#noMatchMsg {
+  color: #dc3545;
+  font-size: .875rem;
+  display: none;
+  margin-top: .25rem;
+}
+

--- a/assets/css/components/wizard-stepper.css
+++ b/assets/css/components/wizard-stepper.css
@@ -2,7 +2,7 @@
 
 /* ────────────────────────────────────────────────────────────────
    GENERAL
-   ────────────────────────────────────────────────────────────────*/
+   ──────────────────────────────────────────────────────────────── */
 body {
   background: #0b1e2d;              /* tono azul-oscuro global   */
   color: #dceefb;                   /* texto casi blanco-celeste */
@@ -24,7 +24,7 @@ body {
 
 /* ────────────────────────────────────────────────────────────────
    STEPPER TRAPEZOIDAL
-   ────────────────────────────────────────────────────────────────*/
+   ──────────────────────────────────────────────────────────────── */
 .stepper {
   display: flex;                    /* pasos en línea            */
   list-style: none;                 /* sin bullets               */
@@ -41,9 +41,10 @@ body {
   background: #0f172a;              /* mismo fondo contenedor    */
   min-width: 180px;                 /* ancho mínimo de paso      */
   clip-path: polygon(10px 0, 100% 0, calc(100% - 10px) 100%, 0% 100%);
+
                                     /* polígono ↗ trapecio       */
   margin-left: -10px;               /* solapado para trapecios   */
-  border-right: 1px solid rgba(255,255,255,0.1); /* línea divisoria */
+  border-right: 1px solid rgb(255 255 255 / 10%); /* línea divisoria */
   z-index: 1;                       /* debajo de activo/done     */
   transition: background .3s, color .3s; /* suavidad hover/cambio */
 }
@@ -58,7 +59,7 @@ body {
 .stepper li.done,
 .stepper li.active {
   background: #1e293b;              /* fondo azul intermedio     */
-  color: #ffffff;                   /* texto blanco              */
+  color: #fff;                   /* texto blanco              */
   z-index: 2;                       /* por encima de inactivos   */
 }
 
@@ -86,26 +87,26 @@ body {
   right: 0;                         /* pegada al borde derecho   */
   top: 10%; bottom: 10%;            /* deja margen arriba/abajo  */
   width: 1px;                       /* grosor línea              */
-  background: rgba(255, 255, 255, .15); /* blanco translúcido   */
+  background: rgb(255 255 255 / 15%); /* blanco translúcido   */
   z-index: 3;                       /* sobre fondo del paso      */
 }
 
 /* ────────────────────────────────────────────────────────────────
    CONTENEDOR CENTRAL
-   ────────────────────────────────────────────────────────────────*/
+   ──────────────────────────────────────────────────────────────── */
 .wizard-body {
   max-width: 1200px;                /* ancho máx. de contenido   */
   margin: 3rem auto;                /* centrado y margen sup.    */
   background: #132330;              /* caja azul oscuro          */
   padding: 2.5rem;                  /* espacio interno generoso  */
   border-radius: .75rem;            /* bordes redondeados        */
-  box-shadow: 0 0 24px rgba(0,0,0,.5); /* sombra envolvente      */
+  box-shadow: 0 0 24px rgb(0 0 0 / 50%); /* sombra envolvente      */
   border: 1px solid #264b63;        /* contorno sutil            */
 }
 
 /* ────────────────────────────────────────────────────────────────
    BOTONES
-   ────────────────────────────────────────────────────────────────*/
+   ──────────────────────────────────────────────────────────────── */
 .btn-primary {
   background-color: #2b8ac6;        /* azul principal            */
   border-color: #256fa1;            /* borde más oscuro          */
@@ -115,6 +116,7 @@ body {
   border-radius: .4rem;             /* bordes redondeados        */
   transition: background .3s, border-color .3s; /* hover suave    */
 }
+
 .btn-primary:hover {
   background-color: #3aa0db;        /* aclaramos al hover        */
   border-color: #2b8ac6;            /* borde acompaña            */
@@ -122,7 +124,7 @@ body {
 
 /* ────────────────────────────────────────────────────────────────
    DEBUG BOX
-   ────────────────────────────────────────────────────────────────*/
+   ──────────────────────────────────────────────────────────────── */
 .debug-box {
   background: #102735;              /* fondo casi negro-azul     */
   color: #a7d3e9;                   /* texto celeste claro       */
@@ -140,8 +142,8 @@ body {
 
 /* ────────────────────────────────────────────────────────────────
    RESPONSIVE: pantallas < 768 px
-   ────────────────────────────────────────────────────────────────*/
-@media (max-width: 768px) {
+   ──────────────────────────────────────────────────────────────── */
+@media (width <= 768px) {
   .stepper li {
     min-width: 100vw;               /* cada paso ocupa la pantalla */
     clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%); /* rectángulo */

--- a/assets/css/material.css
+++ b/assets/css/material.css
@@ -25,37 +25,3 @@ body {
   background: #198754 !important;
   color: #fff !important;
 }
-
-/* Dropdown búsqueda */
-.dropdown-search {
-  position: absolute;
-  width: 100%;
-  max-height: 200px;
-  overflow-y: auto;
-  background: #000;
-  border: 1px solid #444;
-  z-index: 1000;
-  display: none;
-}
-
-.dropdown-search .item {
-  padding: .5rem .75rem;
-  color: #f1f1f1;
-  cursor: pointer;
-}
-
-.dropdown-search .item:hover {
-  background: #333;
-}
-
-.dropdown-search .hl {
-  background: #ffd54f;
-  color: #000;
-}
-
-#noMatchMsg {
-  color: #dc3545;
-  font-size: .875rem;
-  display: none;
-  margin-top: .25rem;
-}

--- a/assets/css/step-common.css
+++ b/assets/css/step-common.css
@@ -1,6 +1,6 @@
 body {
-  background-color: #0d1117;
-  color: #e0e0e0;
+  background-color: var(--color-bg-dark);
+  color: var(--color-text);
   font-family: 'Segoe UI', Roboto, sans-serif;
 }
 
@@ -37,7 +37,7 @@ body {
   border-radius: 0.375rem;
 }
 
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .btn-type,
   .btn-cat,
   .btn-strat,

--- a/assets/css/step1_manual.css
+++ b/assets/css/step1_manual.css
@@ -1,11 +1,13 @@
 /* File: assets/css/step1_manual.css */
+
 /* Estilo v6.0 trapezoidal, adaptado al stepper azul oscuro */
 
 .sidebar {
   min-width: 100%;
   padding-bottom: 1rem;
 }
-@media (min-width: 768px) {
+
+@media (width >= 768px) {
   .sidebar {
     min-width: 260px;
     max-width: 260px;
@@ -18,7 +20,7 @@
   font-size: .85rem;
   padding: .4rem .5rem;
   border-bottom: 1px solid #334155;
-  background: #1e293b;
+  background: var(--color-bg-alt);
   color: #cbd5e1;
 }
 
@@ -27,7 +29,7 @@
   overflow-y: auto;
   padding: .25rem .5rem;
   display: none;
-  background: #0f172a;
+  background: var(--color-bg-darker);
   border-left: 1px solid #334155;
   border-right: 1px solid #334155;
 }
@@ -56,7 +58,8 @@
 .thumb {
   width: 40px;
   height: 40px;
-  object-fit: contain;
+  -o-object-fit: contain;
+     object-fit: contain;
   border: 1px solid #ddd;
 }
 
@@ -83,7 +86,7 @@
   color: #fff;
   padding: .75rem 1rem;
   border-radius: 6px;
-  box-shadow: 0 0 10px rgba(0,0,0,0.3);
+  box-shadow: 0 0 10px rgb(0 0 0 / 30%);
 }
 
 .table-dark {

--- a/assets/css/strategy.css
+++ b/assets/css/strategy.css
@@ -9,6 +9,7 @@ body {
   margin: .35rem .45rem;
   white-space: nowrap;
 }
+
 .btn-cat.active {
   background: #0d6efd !important;
   color: #fff !important;
@@ -18,6 +19,7 @@ body {
   margin: .25rem 0;
   width: 100%;
 }
+
 .btn-strat.active {
   background: #198754 !important;
   color: #fff !important;
@@ -50,37 +52,8 @@ h2, h5 {
   color: #4fc3f7;
 }
 
-/* Dropdown de búsqueda */
-.dropdown-search {
-  position: absolute;
-  width: 100%;
-  max-height: 200px;
-  overflow-y: auto;
-  background: #000;
-  border: 1px solid #444;
-  z-index: 1000;
-  display: none;
-}
-.dropdown-search .item {
-  padding: .5rem .75rem;
-  color: #f1f1f1;
-  cursor: pointer;
-}
-.dropdown-search .item:hover {
-  background: #333;
-}
-.dropdown-search .hl {
-  background: #ffd54f;
-  color: #000;
-}
-#noMatchMsg {
-  color: #dc3545;
-  font-size: .875rem;
-  display: none;
-  margin-top: .25rem;
-}
 
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .btn-cat,
   .btn-strat {
     width: 100%;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,17 @@
+v1.1 CSS modularization
+
+- created base/variables.css with tokens:
+  --color-bg-dark: #0d1117
+  --color-text: #e0e0e0
+  --color-accent: #4fc3f7
+  --color-border: #2c2f33
+  --color-bg-darker: #0f172a
+  --color-bg-alt: #1e293b
+  --radius-lg: 0.75rem
+  --spacer-1: 0.5rem
+  --spacer-2: 1rem
+- new base/layout.css with flex and gap helpers
+- new base/theme.css centralizing body and .btn-primary styles
+- moved wizard.css to components/wizard-stepper.css
+- deduplicated dropdown-search rules from material.css and strategy.css into components/dropdown-search.css
+- updated paths in layout_wizard.php and sample steps (step6.php, manual/step1.php)

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -8,7 +8,11 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Wizard CNC</title>
-  <link rel="stylesheet" href="assets/css/wizard.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/reset.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/variables.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/layout.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/theme.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/components/wizard-stepper.css">
 </head>
 <body>
 
@@ -47,8 +51,7 @@
   <?php endif; ?>
   <script src="assets/js/stepper.js" defer></script>
   <script src="assets/js/dashboard.js" defer></script>
-<link rel="stylesheet" href="assets/css/wizard.css">
-<link rel="stylesheet" href="assets/css/step6.css"><!-- <---- AGREGALO ACÁ -->
+
 
 </body>
 </html>

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -122,8 +122,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         rel="stylesheet">
 
   <!-- Estilos propios -->
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/reset.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/variables.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/layout.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/theme.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/components/wizard-stepper.css">
   <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step1_manual.css">
-
   <link rel="stylesheet" href="/wizard-stepper_git/assets/css/steps/manual/step1.css">
 </head>
 <body>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -233,6 +233,11 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Cutting Data Épico – Paso 6</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/reset.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/variables.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/layout.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/theme.css">
+  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/components/wizard-stepper.css">
   <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step6.css">
   
 </head>


### PR DESCRIPTION
## Summary
- centralize colors & spacing in `variables.css`
- add layout helpers and brand theme styles
- split dropdown-search into its own component
- move wizard styles under `components/wizard-stepper.css`
- update layout and selected step pages to use new CSS files
- add stylelint config

## Testing
- `npx stylelint "assets/css/**/*.css" --fix` *(fails: various lint errors)*
- `npx postcss assets/css/components/wizard-stepper.css --use autoprefixer -o assets/css/components/wizard-stepper.css`

------
https://chatgpt.com/codex/tasks/task_e_68521cae2170832cbc5c32ea846273a2