### PR TITLE
Update wizard helpers and lint configs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+- Added basic Stylelint, ESLint and PHPCS configuration files.
+- Applied `phpcbf` auto-fixes to step views.
+- Introduced `includes/wizard_helpers.php` with shared `dbg` stub.
+- Injected `pageshow` listener in `step6.php`.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,10 @@
+export default [
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: "module",
+    },
+    rules: {},
+  },
+];

--- a/includes/wizard_helpers.php
+++ b/includes/wizard_helpers.php
@@ -1,0 +1,8 @@
+<?php
+// Shared helper stubs for the wizard steps
+if (!function_exists('dbg')) {
+    function dbg(...$args): void
+    {
+        // Real implementation may be defined in includes/debug.php
+    }
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="Project">
+    <rule ref="PSR12" />
+    <fileset>
+        <directory>.</directory>
+        <exclude-pattern>vendor</exclude-pattern>
+        <exclude-pattern>node_modules</exclude-pattern>
+    </fileset>
+</ruleset>

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -37,15 +37,10 @@ if ($DEBUG) {
     error_reporting(0);
     ini_set('display_errors', '0');
 }
-if (!function_exists('dbg')) {
-    function dbg(string $msg, $data = null): void {
-        global $DEBUG;
-        if ($DEBUG) {
-            error_log("[step1.php] " . $msg . ' ' . json_encode($data, JSON_UNESCAPED_UNICODE));
-        }
-    }
+require_once __DIR__ . '/../../../includes/wizard_helpers.php';
+if ($DEBUG && function_exists('dbg')) {
+    dbg('🔧 step1.php iniciado');
 }
-dbg('🔧 step1.php iniciado');
 
 // -------------------------------------------
 // [C] Inicio de sesión seguro

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -35,15 +35,10 @@ if ($DEBUG) {
     error_reporting(0);
     ini_set('display_errors', '0');
 }
-if (!function_exists('dbg')) {
-    function dbg(string $msg): void {
-        global $DEBUG;
-        if ($DEBUG) {
-            error_log("[step2.php] " . $msg);
-        }
-    }
+require_once __DIR__ . '/../../../includes/wizard_helpers.php';
+if ($DEBUG && function_exists('dbg')) {
+    dbg('🔧 step2.php iniciado');
 }
-dbg('🔧 step2.php iniciado');
 
 // -------------------------------------------
 // [C] Inicio de sesión seguro

--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -39,10 +39,10 @@ if ($DEBUG && is_readable(__DIR__ . '/../../../includes/debug.php')) {
     require_once __DIR__ . '/../../../includes/debug.php';
     dbg("🔧 [step3] Iniciando paso 3 (Modo Auto) con DEBUG=1");
 } else {
-    if (!function_exists('dbg')) {
-        function dbg(...$args) { /* stub si no está debug.php */ }
+    require_once __DIR__ . '/../../../includes/wizard_helpers.php';
+    if (function_exists('dbg')) {
+        dbg("🔧 [step3] Iniciando paso 3 (Modo Auto) sin DEBUG");
     }
-    dbg("🔧 [step3] Iniciando paso 3 (Modo Auto) sin DEBUG");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -34,15 +34,10 @@ if ($DEBUG) {
     error_reporting(0);
     ini_set('display_errors', '0');
 }
-if (!function_exists('dbg')) {
-    function dbg(string $tag, $data = null): void {
-        global $DEBUG;
-        if ($DEBUG) {
-            error_log("[step4.php] " . $tag . ' ' . json_encode($data, JSON_UNESCAPED_UNICODE));
-        }
-    }
+require_once __DIR__ . '/../../../includes/wizard_helpers.php';
+if ($DEBUG && function_exists('dbg')) {
+    dbg('🔧 step4.php iniciado');
 }
-dbg('🔧 step4.php iniciado');
 
 // -------------------------------------------
 // [C] Inicio de sesión seguro

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -38,9 +38,7 @@ if ($DEBUG && is_readable(__DIR__ . '/../../../includes/debug.php')) {
     require_once __DIR__ . '/../../../includes/debug.php';
     dbg('Sesión wizard cargada. Progreso actual: ' . $currentProgress);
 } else {
-    if (!function_exists('dbg')) {
-        function dbg() { /* stub */ }
-    }
+    require_once __DIR__ . '/../../../includes/wizard_helpers.php';
 }
 
 // ──────────────── 4) Conexión a BD (solo si luego necesitas datos) ────

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -35,15 +35,10 @@ if ($DEBUG) {
     error_reporting(0);
     ini_set('display_errors', '0');
 }
-if (!function_exists('dbg')) {
-    function dbg(string $msg, $data = null): void {
-        global $DEBUG;
-        if ($DEBUG) {
-            error_log('[step3.php] ' . $msg . ' ' . json_encode($data, JSON_UNESCAPED_UNICODE));
-        }
-    }
+require_once __DIR__ . '/../../../includes/wizard_helpers.php';
+if ($DEBUG && function_exists('dbg')) {
+    dbg('🔧 step3.php iniciado');
 }
-dbg('🔧 step3.php iniciado');
 
 /* ──────────────────────────────────────────────────────
  * [C]  Sesión segura

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -40,16 +40,10 @@ if ($DEBUG) {
     error_reporting(0);
     ini_set('display_errors', '0');
 }
-if (!function_exists('dbg')) {
-    function dbg(string $msg, $data = null): void
-    {
-        global $DEBUG;
-        if ($DEBUG) {
-            error_log('[step4.php] ' . $msg . ' ' . json_encode($data, JSON_UNESCAPED_UNICODE));
-        }
-    }
+require_once __DIR__ . '/../../../includes/wizard_helpers.php';
+if ($DEBUG && function_exists('dbg')) {
+    dbg('🔧 step4.php iniciado');
 }
-dbg('🔧 step4.php iniciado');
 
 //────────────────────────────────────────────────────────────────────
 // [C] Sesión segura

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -23,9 +23,7 @@ if (!$embedded) {
 }
 
 // Stub de dbg()
-if (!function_exists('dbg')) {
-    function dbg(...$args) { /* stub vacío si no hay debug.php */ }
-}
+require_once __DIR__ . '/../../includes/wizard_helpers.php';
 
 // [B] SESIÓN SEGURA
 if (session_status() !== PHP_SESSION_ACTIVE) {
@@ -631,6 +629,13 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js"></script>
 <script src="/wizard-stepper_git/assets/js/step6.js"></script>
+<script>
+  window.addEventListener('pageshow', (e) => {
+    if (e.persisted) {
+      window.location.reload();
+    }
+  });
+</script>
   </div>
 
 <?php if (!$embedded): ?>


### PR DESCRIPTION
## Summary
- add ESLint, Stylelint, PHPCS configs
- create new `wizard_helpers.php` shared stub
- hook helpers from wizard steps
- reload step6 view on bfc events
- add changelog entry

## Testing
- `npx stylelint "assets/css/**/*.css" --fix` *(fails: ConfigurationError)*
- `npx eslint assets/js/**/*.js --fix`
- `~/.config/composer/vendor/bin/phpcbf $(find views/steps -name 'step*.php')`
- `~/.config/composer/vendor/bin/phpcs $(find views/steps -name 'step*.php')`
- `~/.config/composer/vendor/bin/phpstan analyse views/steps --level 5`

------
https://chatgpt.com/codex/tasks/task_e_685225759264832c9d7e85a45f54901d