### PR TITLE
Fix wizard stepper overflow

### DIFF
--- a/assets/js/stepper.js
+++ b/assets/js/stepper.js
@@ -153,7 +153,8 @@
           alert(js.error || 'Error al procesar');
           return;
         }
-        const next = js.next ?? cur + 1;
+        let next = (typeof js.next === 'number') ? js.next : cur + 1;
+        if (next > MAX_STEPS) next = MAX_STEPS;
         setProg(next);
         loadStep(next);
       })

--- a/public/handle-step.php
+++ b/public/handle-step.php
@@ -9,12 +9,12 @@ use IndustrialWizard\StepperFlow;
 header('Content-Type: application/json');
 
 $step = filter_input(INPUT_POST,'step',FILTER_VALIDATE_INT);
-if (!$step || !StepperFlow::isAllowed($step)) {
+$mode = $_SESSION['tool_mode'] ?? ($_POST['tool_mode'] ?? 'manual');
+if (!$step || !StepperFlow::isAllowed($step, $mode)) {
     echo json_encode(['success'=>false,'error'=>'Paso inválido']);
     exit;
 }
 
-$mode = $_SESSION['tool_mode'] ?? ($_POST['tool_mode'] ?? 'manual');
 
 // Guardar modo si es paso 1
 if ($step === 1 && isset($_POST['tool_mode'])) {

--- a/src/StepperFlow.php
+++ b/src/StepperFlow.php
@@ -25,11 +25,14 @@ class StepperFlow
     {
         $flow = self::get($mode);
         $i    = array_search($current, $flow, true);
-        return $flow[$i+1] ?? null;
+        if ($i === false || !isset($flow[$i + 1])) {
+            return null;
+        }
+        return $flow[$i + 1];
     }
 
-    public static function isAllowed(int $step): bool
+    public static function isAllowed(int $step, string $mode = 'manual'): bool
     {
-        return $step >= 1 && $step <= 6;
+        return in_array($step, self::get($mode), true);
     }
 }


### PR DESCRIPTION
## Summary
- validate wizard step by mode
- handle missing next step without overflowing past the last step
- stop JS stepper from going beyond final step

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522bdc9780832c9e608e32808f8a6f