### PR TITLE
Add HTML sanitizer helper

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -24,7 +24,7 @@ function respond_json($data) {
  * @param string $key Clave de sesión
  * @return mixed|null
  */
-function session_get(string $key) {
+function session_get(string $key)
+{
     return $_SESSION[$key] ?? null;
 }
-?>

--- a/includes/security.php
+++ b/includes/security.php
@@ -53,3 +53,14 @@ function validate_csrf_token(?string $token): bool
     }
     return hash_equals($_SESSION['csrf_token'], $token);
 }
+
+/**
+ * Escape a string for safe HTML output.
+ *
+ * @param string|null $value Raw value to escape
+ * @return string Escaped value
+ */
+function h(?string $value): string
+{
+    return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8');
+}

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -18,7 +18,7 @@
       <?php foreach ($flow as $n): ?>
         <li
           data-step="<?= $n ?>"
-          data-label="<?= htmlspecialchars($labels[$n], ENT_QUOTES) ?>"></li>
+          data-label="<?= h($labels[$n]) ?>"></li>
       <?php endforeach; ?>
     </ul>
   </nav>
@@ -42,7 +42,7 @@
   <!-- Scripts -->
   <?php if (!empty($_SESSION['csrf_token'])): ?>
   <script>
-    window.csrfToken = '<?= htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8') ?>';
+    window.csrfToken = '<?= h($_SESSION['csrf_token']) ?>';
   </script>
   <?php endif; ?>
   <script src="assets/js/stepper.js" defer></script>

--- a/views/select_mode.php
+++ b/views/select_mode.php
@@ -22,7 +22,7 @@
     Elegí uno de los dos modos según tu experiencia previa:
   </p>
   <form method="post" action="index.php">
-    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES) ?>">
+    <input type="hidden" name="csrf_token" value="<?= h($csrfToken) ?>">
     <div class="mode-options">
       <label class="mode-option">
         <input type="radio" name="tool_mode" value="manual" required>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -131,10 +131,10 @@ if ($jsonParams === false) {
 
 // [J] PREPARAR VARIABLES PARA LA VISTA
 // Datos herramienta
-$serialNumber  = htmlspecialchars($toolData['serie']       ?? '', ENT_QUOTES);
-$toolCode      = htmlspecialchars($toolData['tool_code']   ?? '', ENT_QUOTES);
-$toolName      = htmlspecialchars($toolData['name']        ?? 'N/A', ENT_QUOTES);
-$toolType      = htmlspecialchars($toolData['tool_type']   ?? 'N/A', ENT_QUOTES);
+$serialNumber  = h($toolData['serie']       ?? '');
+$toolCode      = h($toolData['tool_code']   ?? '');
+$toolName      = h($toolData['name']        ?? 'N/A');
+$toolType      = h($toolData['tool_type']   ?? 'N/A');
 
 // Imágenes
 
@@ -157,10 +157,10 @@ $fluteLenMb    = (float)($toolData['flute_length_mm']   ?? 0);
 $cutLenMb      = (float)($toolData['cut_length_mm']     ?? 0);
 $fullLenMb     = (float)($toolData['full_length_mm']    ?? 0);
 $fluteCountMb  = (int)  ($toolData['flute_count']        ?? 0);
-$coatingMb     = htmlspecialchars($toolData['coated']    ?? 'N/A', ENT_QUOTES);
-$materialMb    = htmlspecialchars($toolData['material']  ?? 'N/A', ENT_QUOTES);
-$brandMb       = htmlspecialchars($toolData['brand']     ?? 'N/A', ENT_QUOTES);
-$madeInMb      = htmlspecialchars($toolData['made_in']   ?? 'N/A', ENT_QUOTES);
+$coatingMb     = h($toolData['coated']    ?? 'N/A');
+$materialMb    = h($toolData['material']  ?? 'N/A');
+$brandMb       = h($toolData['brand']     ?? 'N/A');
+$madeInMb      = h($toolData['made_in']   ?? 'N/A');
 
 // Parámetros técnicos base
 $baseVc        = (float)$params['vc0'];
@@ -244,7 +244,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
     <strong>⚠️ Archivos faltantes (se usarán CDNs):</strong>
     <ul>
       <?php foreach ($assetErrors as $err): ?>
-        <li><?= htmlspecialchars($err ?? '', ENT_QUOTES) ?></li>
+        <li><?= h($err ?? '') ?></li>
       <?php endforeach; ?>
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- add an `h()` helper to escape HTML
- use the helper in layout template, select mode form, and step 6 view
- remove closing tag from `includes/functions.php`

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68522c18e214832c9a03d7010469d552