### PR TITLE
Fix IDE error for ExpertResultController in step6.php

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -2,6 +2,8 @@
 // File: C:\xampp\htdocs\wizard-stepper_git\views\steps\step6.php
 declare(strict_types=1);
 
+use App\Controller\ExpertResultController;
+
 // ──────────────────────────────────────────────────────────────
 // ¿Se carga directo o embebido en load-step.php?
 // Si index.php incluyó esta vista → define('WIZARD_EMBEDDED', true)


### PR DESCRIPTION
## Summary
- import the namespaced `ExpertResultController` in `step6.php`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685235ec8dd8832c9f22007d472000c9