### PR TITLE
Fix unused label in step6

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -38,7 +38,6 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 }
 
 // [C] DEBUG OPCIONAL
-detectDebug:
 $DEBUG = filter_input(INPUT_GET, 'debug', FILTER_VALIDATE_BOOLEAN);
 if ($DEBUG && is_readable(__DIR__ . '/../../includes/debug.php')) {
     require_once __DIR__ . '/../../includes/debug.php';


### PR DESCRIPTION
## Summary
- clean up unused `detectDebug` label in step6 view

## Testing
- `npm run lint:css` *(fails: stylelint errors in repository)*
- `php -l views/steps/step6.php`

------
https://chatgpt.com/codex/tasks/task_e_685235fa4668832ca9ee751f8c5da44b