### PR TITLE
Remove next button from auto step3

### DIFF
--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -171,11 +171,7 @@ try {
     <input type="hidden" id="tool_table" name="tool_table" value="">
   </form>
 
-  <div class="text-end mt-4">
-    <button type="submit" form="selectForm" class="btn btn-primary btn-lg" id="btn-next" disabled>
-      Siguiente →
-    </button>
-  </div>
+  <!-- Botón "Siguiente" removido -->
 
   <!-- 7.4) Consola interna de debugging -->
   <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>


### PR DESCRIPTION
## Summary
- remove 'Siguiente' next button from auto step3 page

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852de02274c832cb7c675eaca60acea