### PR TITLE
Improve step6 layout

### DIFF
--- a/assets/css/step6.css
+++ b/assets/css/step6.css
@@ -24,7 +24,7 @@
 @media (prefers-color-scheme: light) {
   :root {
     --bg-body: #f6f8fa;
-    --bg-card: #ffffff;
+    --bg-card: #fff;
     --bg-header: #eaf2f8;
     --border-color: #d0d7de;
     --text-color: #24292e;
@@ -51,6 +51,7 @@ body {
   border-radius: 0.5rem;
   margin-bottom: 1rem;
 }
+
 .card-header {
   background: var(--bg-header);
   border-bottom: 1px solid var(--border-color);
@@ -58,6 +59,7 @@ body {
   font-weight: 600;
   text-align: center;
 }
+
 .card.h-100 {
   display: flex;
   flex-direction: column;
@@ -70,11 +72,13 @@ body {
   max-height: 120px;
   object-fit: contain;
 }
+
 .tool-name {
   font-size: 1.1rem;
   font-weight: 600;
   margin-top: 0.5rem;
 }
+
 .tool-type {
   color: var(--text-color-sec);
   font-size: 0.95rem;
@@ -86,14 +90,17 @@ body {
   padding-left: 0;
   margin: 0;
 }
+
 .spec-list li {
   margin-bottom: 0.4rem;
   display: flex;
   justify-content: space-between;
 }
+
 .spec-list li span:first-child {
   color: var(--text-color-sec);
 }
+
 .spec-list li span:last-child {
   color: var(--accent-color);
   font-weight: 600;
@@ -110,10 +117,11 @@ body {
 /* Grid tarjetas */
 .cards-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1rem;
   align-items: flex-start;
 }
+
 .cards-grid [class*="col-"] {
   width: auto !important;
   flex: 0 0 auto !important;
@@ -125,7 +133,8 @@ body {
   font-weight: 600;
   margin-bottom: 0.3rem;
 }
-input[type=range].form-range {
+
+input[type="range"].form-range {
   width: 100%;
   height: 6px;
   background: var(--border-color);
@@ -133,10 +142,12 @@ input[type=range].form-range {
   appearance: none;
   cursor: pointer;
 }
-input[type=range].form-range:focus {
+
+input[type="range"].form-range:focus {
   outline: none;
 }
-input[type=range].form-range::-webkit-slider-thumb {
+
+input[type="range"].form-range::-webkit-slider-thumb {
   appearance: none;
   width: var(--slider-thumb-size);
   height: var(--slider-thumb-size);
@@ -146,8 +157,9 @@ input[type=range].form-range::-webkit-slider-thumb {
   cursor: pointer;
   margin-top: -5px;
 }
-input[type=range].form-range::-moz-range-thumb,
-input[type=range].form-range::-ms-thumb {
+
+input[type="range"].form-range::-moz-range-thumb,
+input[type="range"].form-range::-ms-thumb {
   width: var(--slider-thumb-size);
   height: var(--slider-thumb-size);
   background: var(--accent-color);
@@ -155,9 +167,10 @@ input[type=range].form-range::-ms-thumb {
   border-radius: 50%;
   cursor: pointer;
 }
-input[type=range].form-range::-webkit-slider-runnable-track,
-input[type=range].form-range::-moz-range-track,
-input[type=range].form-range::-ms-track {
+
+input[type="range"].form-range::-webkit-slider-runnable-track,
+input[type="range"].form-range::-moz-range-track,
+input[type="range"].form-range::-ms-track {
   background: var(--border-color);
   height: 6px;
   border-radius: 3px;
@@ -181,6 +194,7 @@ input[type=range].form-range::-ms-track {
 .text-end.small.text-secondary {
   color: var(--text-color-sec) !important;
 }
+
 #valFz, #valVc, #valAe {
   color: var(--accent-color);
   font-weight: 600;
@@ -191,8 +205,9 @@ input[type=range].form-range::-ms-track {
   color: var(--text-color-sec);
   font-size: 0.85rem;
 }
+
 #errorMsg {
-  color: #ff4444;
+  color: #f44;
   font-size: 0.85rem;
   display: none;
 }
@@ -207,10 +222,12 @@ input[type=range].form-range::-ms-track {
   border: 1px solid var(--border-color);
   border-radius: 0.25rem;
 }
+
 .param-label {
   color: var(--text-color-sec);
   font-size: 0.75rem;
 }
+
 .fw-bold {
   color: var(--accent-color);
   font-size: 1.1rem;
@@ -226,25 +243,30 @@ input[type=range].form-range::-ms-track {
 .config-card-static {
   padding: 0.8rem;
 }
+
 .config-section-title {
   color: var(--text-color-sec);
   font-weight: 600;
   margin-bottom: 0.25rem;
 }
+
 .config-item {
   display: flex;
   justify-content: space-between;
   margin: 0.25rem 0;
 }
+
 .label-static {
   color: var(--text-color-sec);
 }
+
 .value-static {
   color: var(--accent-color);
   font-weight: 600;
 }
+
 .section-divider {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid rgb(255 255 255 / 10%);
   margin: 0.5rem 0;
 }
 
@@ -252,26 +274,31 @@ input[type=range].form-range::-ms-track {
 .notes-card {
   padding: 0.8rem;
 }
+
 .notes-list {
   list-style: none;
   padding: 0;
   margin: 0;
 }
+
 .notes-list li {
   display: flex;
   gap: 0.5rem;
   padding: 0.25rem 0;
   align-items: flex-start;
 }
+
 .notes-list li i {
   font-size: 1rem;
   margin-top: 0.2rem;
   color: var(--accent-color);
 }
+
 .notes-list li div {
   color: var(--text-color);
   font-size: 0.9rem;
 }
+
 .text-secondary {
   color: var(--text-color-sec) !important;
 }
@@ -279,8 +306,8 @@ input[type=range].form-range::-ms-track {
 /* Spinner */
 .spinner-overlay {
   position: absolute;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  inset: 0;
+  background: rgb(0 0 0 / 50%);
   border-radius: 0.5rem;
   display: flex;
   justify-content: center;
@@ -288,9 +315,11 @@ input[type=range].form-range::-ms-track {
   visibility: hidden;
   z-index: 10;
 }
+
 .spinner-overlay.show {
   visibility: visible;
 }
+
 .spinner-border {
   width: var(--spinner-size);
   height: var(--spinner-size);
@@ -299,25 +328,29 @@ input[type=range].form-range::-ms-track {
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
+
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
 
 /* Debug */
 body.debug-mode * {
-  outline: 1px solid rgba(255, 0, 0, 0.2);
+  outline: 1px solid rgb(255 0 0 / 20%);
 }
+
 body.debug-mode .card {
   outline: 1px dashed magenta;
 }
+
 .debug-outline {
   outline: 2px solid #e00 !important;
 }
+
 .debug-panel {
   position: fixed;
   bottom: 0; left: 0; right: 0;
   max-height: 150px;
-  background: rgba(0, 0, 0, 0.8);
+  background: rgb(0 0 0 / 80%);
   color: #0f0;
   font-family: Consolas, monospace;
   font-size: 0.85rem;
@@ -326,15 +359,17 @@ body.debug-mode .card {
   display: none;
   z-index: 9999;
 }
+
 .debug-panel.show {
   display: block;
 }
 
 /* Mobile */
-@media (max-width: 991px) {
+@media (width <= 991px) {
   .content-main {
     margin-bottom: 12rem;
   }
+
   .slider-box {
     position: fixed;
     bottom: 0;

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -257,10 +257,10 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 
 
 <!-- BLOQUE CENTRAL HTML -->
-<div class="container-fluid py-3 content-main dashboard-grid">
+<div class="container-fluid py-3 content-main">
   <!-- ENCABEZADO DE HERRAMIENTA -->
   <div class="container py-3">
-    <div class="row gx-3 mb-4">
+    <div class="row gx-3 mb-4 cards-grid">
       <div class="col-12 col-lg-4 mb-3 area-tool">
         <div class="card h-100 shadow-sm">
           <div class="card-header text-center p-3">
@@ -286,7 +286,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 
   <!-- FILA: Sliders / Resultados / Radar -->
   <div class="container py-3">
-    <div class="row gx-3 mb-4">
+    <div class="row gx-3 mb-4 cards-grid">
 
       <!-- 1) Ajustes (Sliders) -->
       <div class="col-12 col-lg-4 mb-3 area-sliders">
@@ -465,7 +465,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 
   <!-- ESPECIFICACIONES TÉCNICAS & IMAGEN VECTORIAL -->
   <div class="container py-3">
-    <div class="row gx-3 mb-4">
+    <div class="row gx-3 mb-4 cards-grid">
 
       <div class="col-12 col-lg-4 mb-3">
         <div class="card h-100 shadow-sm">


### PR DESCRIPTION
## Summary
- use grid layout by applying `cards-grid` class on step 6 rows
- tweak grid column size in `step6.css`

## Testing
- `npm run lint:css` *(fails: declaration-block-single-line-max-declarations and selector-id-pattern errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852dd8b88a8832c805f8a2173c36751