### PR TITLE
Add security headers to Step 1 and AJAX endpoint

### DIFF
--- a/ajax/tools_scroll.php
+++ b/ajax/tools_scroll.php
@@ -7,13 +7,13 @@ require_once __DIR__ . '/../src/Utils/Session.php';
 require_once __DIR__ . '/../includes/db.php';
 
 header('Content-Type: application/json; charset=UTF-8');
-header('Strict-Transport-Security: max-age=63072000; includeSubDomains; preload');
+header('Strict-Transport-Security: max-age=31536000; includeSubDomains; preload');
 header('X-Frame-Options: DENY');
 header('X-Content-Type-Options: nosniff');
 header('X-XSS-Protection: 1; mode=block');
 header('Referrer-Policy: no-referrer');
 header('Permissions-Policy: geolocation=(), microphone=()');
-header("Content-Security-Policy: default-src 'self'");
+header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');
 

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -16,6 +16,17 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
     ]);
 }
 
+// ──────────────── Cabeceras de seguridad ────────────────────────────
+header('Content-Type: text/html; charset=UTF-8');
+header("Strict-Transport-Security: max-age=31536000; includeSubDomains; preload");
+header("X-Frame-Options: DENY");
+header("X-Content-Type-Options: nosniff");
+header("Referrer-Policy: no-referrer");
+header("Permissions-Policy: geolocation=(), microphone=()");
+header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
+header("Pragma: no-cache");
+header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");
+
 // ──────────────── 2) Estado del wizard ──────────────────────────────
 // Si aún no se inició el wizard, lo inicializamos en Paso 1
 if (empty($_SESSION['wizard_state']) || $_SESSION['wizard_state'] !== 'wizard') {


### PR DESCRIPTION
## Summary
- enforce security headers in manual step1 page
- align CSP and HSTS settings on tools_scroll.php

## Testing
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_6852ed1341a4832c850be75bbce97ba6