### PR TITLE
Fix lazy loading CSRF and reset state

### DIFF
--- a/assets/js/step1_lazy.js
+++ b/assets/js/step1_lazy.js
@@ -67,6 +67,10 @@ const observer = new IntersectionObserver(
 
 export function initLazy() {
   if (toolList && sentinel) {
+    page = 1;
+    loading = false;
+    hasMore = true;
+    toolList.innerHTML = '';
     observer.observe(sentinel);
   }
 }

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -238,6 +238,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           onload="window._TOOL_BROWSER_LOADED=true"
           onerror="console.error('❌ step1_manual_browser.js no cargó');">
   </script>
+  <script>
+    window.csrfToken = '<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>';
+  </script>
   <script type="module" src="/wizard-stepper_git/assets/js/step1_lazy.js"></script>
 
   <!-- Alerta si no cargó el JS externo -->


### PR DESCRIPTION
## Summary
- set `window.csrfToken` when step1 manual is loaded outside the wizard
- reset lazy loading state when initializing step1

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ef262560832c9e38244543cd83e5