### PR TITLE
Fix lazy scroll initialization for step 1

### DIFF
--- a/assets/js/step1_lazy.js
+++ b/assets/js/step1_lazy.js
@@ -76,3 +76,5 @@ export function initLazy() {
 }
 
 document.addEventListener('DOMContentLoaded', initLazy);
+if (document.readyState !== 'loading') initLazy();
+window.initLazy = initLazy;

--- a/assets/js/stepper.js
+++ b/assets/js/stepper.js
@@ -122,6 +122,7 @@
         stepHolder.style.opacity = '1';
         renderBar(step);
         hookEvents();
+        if (typeof window.initLazy === 'function') window.initLazy();
         dbgMsg(`🧭 Paso ${step} cargado correctamente`);
       })
       .catch(err => {


### PR DESCRIPTION
## Summary
- trigger `initLazy` on script load so infinite scroll works again
- call `initLazy` after each AJAX step load

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_6852f1da5f48832c88107c93c6cfdf55