### PR TITLE
Fix CSP issues and lazy load

### DIFF
--- a/README_scroll_fix.md
+++ b/README_scroll_fix.md
@@ -1,0 +1,29 @@
+# Fix de Scroll Infinito en Paso 1
+
+## Causa raíz
+El listado de herramientas en `step1.php` se cargaba usando un script inline que inicializaba la lógica de scroll. La política CSP bloqueaba estos scripts inline por no estar firmados y el token CSRF se pasaba también mediante otro script inline. Como resultado el `IntersectionObserver` nunca disparaba porque el JS no se ejecutaba y la primera página quedaba vacía.
+
+## Solución
+Se movieron los scripts inline a un módulo externo `assets/js/step1_manual_hook.js`. El token CSRF ahora se expone mediante una etiqueta `<meta>` y es leído por los módulos. La CSP se actualizó para permitir únicamente scripts propios y uno firmado con `nonce`. Dentro de `step1_lazy.js` se ajustó la inicialización para que siempre cargue la primera página y se añadió un alto mínimo al *sentinel*.
+
+## Pasos para reproducir
+1. Abrir `step1.php` antes de aplicar el fix y observar en la consola del navegador errores CSP y que la lista no se carga.
+2. Con la actualización, recargar la página y verificar que el primer lote de fresas aparece automáticamente.
+3. Hacer scroll hasta que `hasMore` sea `false` para confirmar que el scroll infinito funciona.
+
+## Cabeceras CSP finales
+```
+Content-Security-Policy: default-src 'self';
+        script-src 'self' 'nonce-<valor>'; 
+        style-src  'self' 'unsafe-inline';
+```
+
+## Pruebas
+- `./vendor/bin/phpunit` – ejecuta las pruebas unitarias (si existen).
+- `npm run lint` – ejecuta `eslint` sobre los archivos JS.
+- `composer run-script lint` – ejecuta `php -l` sobre los archivos PHP.
+
+Para limpiar la caché APCu manualmente:
+```bash
+php -r 'apcu_clear_cache();'
+```

--- a/assets/js/step1_lazy.js
+++ b/assets/js/step1_lazy.js
@@ -2,6 +2,8 @@ export let page = 1;
 export let loading = false;
 export let hasMore = true;
 
+const csrf = document
+  .querySelector('meta[name="csrf-token"]')?.content || '';
 const toolList = document.getElementById('tool-list');
 const sentinel = document.getElementById('sentinel');
 let controller;
@@ -21,7 +23,7 @@ export async function loadPage() {
     const res = await fetch(`/wizard-stepper_git/ajax/tools_scroll.php?page=${page}`, {
       cache: 'no-store',
       signal: controller.signal,
-      headers: window.csrfToken ? { 'X-CSRF-Token': window.csrfToken } : {}
+      headers: csrf ? { 'X-CSRF-Token': csrf } : {}
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
@@ -67,11 +69,13 @@ const observer = new IntersectionObserver(
 
 export function initLazy() {
   if (toolList && sentinel) {
+    sentinel.style.minHeight = '1px';
     page = 1;
     loading = false;
     hasMore = true;
     toolList.innerHTML = '';
     observer.observe(sentinel);
+    loadPage();
   }
 }
 

--- a/assets/js/step1_manual_hook.js
+++ b/assets/js/step1_manual_hook.js
@@ -1,0 +1,24 @@
+export function dbg(...m) {
+  console.log('[DBG]', ...m);
+  const box = document.getElementById('debug');
+  if (box) box.textContent += m.join(' ') + '\n';
+}
+
+export function initToolTable() {
+  window.dbg = dbg;
+  dbg('hook externo activo');
+  const tbl = document.getElementById('toolTbl');
+  if (!tbl) {
+    dbg('tabla no encontrada');
+    return;
+  }
+
+  tbl.addEventListener('click', e => {
+    const btn = e.target.closest('.select-btn');
+    if (!btn) return;
+    document.getElementById('tool_id').value = btn.dataset.tool_id;
+    document.getElementById('tool_table').value = btn.dataset.tbl;
+    document.getElementById('step1ManualForm').requestSubmit();
+    dbg('► herramienta seleccionada:', btn.dataset.tbl, btn.dataset.tool_id);
+  });
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="WizardTests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -25,7 +25,8 @@ header("Referrer-Policy: no-referrer");
 header("Permissions-Policy: geolocation=(), microphone=()");
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
-header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");
+$nonce = base64_encode(random_bytes(16));
+header("Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-$nonce'; style-src  'self' 'unsafe-inline';");
 
 // ──────────────── 2) Estado del wizard ──────────────────────────────
 // Si aún no se inició el wizard, lo inicializamos en Paso 1
@@ -121,6 +122,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <html lang="es">
 <head>
   <meta charset="utf-8">
+  <meta name="csrf-token" content="<?= htmlspecialchars($csrfToken) ?>">
   <title>Paso 1 – Explorador de fresas (Manual)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -238,59 +240,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           onload="window._TOOL_BROWSER_LOADED=true"
           onerror="console.error('❌ step1_manual_browser.js no cargó');">
   </script>
-  <script>
-    window.csrfToken = '<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>';
-  </script>
   <script type="module" src="/wizard-stepper_git/assets/js/step1_lazy.js"></script>
 
-  <!-- Alerta si no cargó el JS externo -->
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      setTimeout(() => {
-        if (!window._TOOL_BROWSER_LOADED) {
-          const msg = '❌ Falló la carga de step1_manual_browser.js';
-          console.error(msg);
-          document.getElementById('step1ManualForm')
-                  .insertAdjacentHTML(
-                    'afterbegin',
-                    '<div class="alert alert-danger m-2">'+ msg +'</div>'
-                  );
-        }
-      }, 1000);
-    });
-  </script>
-
-  <!-- hook inline (no tocar tu JS externo) -->
-  <script>
-    /* helper global: imprime en consola + #debug */
-    window.dbg = (...m) => {
-      console.log('[DBG]', ...m);
-      const box = document.getElementById('debug');
-      if (box) box.textContent += m.join(' ') + '\n';
-    };
-
-    (() => {
-      dbg('hook inline activo');
-      const tbl = document.getElementById('toolTbl');
-      if (!tbl) {
-        dbg('tabla no encontrada');
-        return;
-      }
-
-      tbl.addEventListener('click', e => {
-        const btn = e.target.closest('.select-btn');
-        if (!btn) return;
-
-        // Capturamos dataset de la fila seleccionada
-        document.getElementById('tool_id').value    = btn.dataset.tool_id;
-        document.getElementById('tool_table').value = btn.dataset.tbl;
-
-        // Enviamos el formulario automáticamente luego de la selección
-        document.getElementById('step1ManualForm').requestSubmit();
-
-        dbg('► herramienta seleccionada:', btn.dataset.tbl, btn.dataset.tool_id);
-      });
-    })();
+  <script type="module" nonce="<?= $nonce ?>">
+    import { initToolTable } from '/wizard-stepper_git/assets/js/step1_manual_hook.js';
+    initToolTable();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add nonce-based CSP and meta CSRF token
- move inline hook to external module
- adjust lazy loader to read meta token and load first page
- document fix

## Testing
- `php -l views/steps/manual/step1.php`
- `npx eslint assets/js/step1_lazy.js assets/js/step1_manual_hook.js` *(fails: ESM config issue)*

------
https://chatgpt.com/codex/tasks/task_e_6852f5ebb1e8832c9e3d182e98fda38c