### PR TITLE
feat: refactor wizard styles + lucide

### DIFF
--- a/README_stepper_refactor.md
+++ b/README_stepper_refactor.md
@@ -1,0 +1,17 @@
+# Refactor de estilos Wizard CNC
+
+Esta actualización agrega un theme global y reemplaza los íconos Feather por Lucide.
+
+## Cómo probar
+1. Instalar dependencias opcionales:
+   ```bash
+   npm install
+   ```
+2. Ejecutar lint y verificación de PHP:
+   ```bash
+   npm run lint:css
+   find . -name '*.php' -exec php -l {} \;
+   ```
+3. Abrí `index.php` en tu servidor y recorré los pasos. Probá en móvil, tablet y escritorio.
+
+El layout se adaptará a tres tamaños y los íconos se renderizan al cargar cada paso.

--- a/assets/css/base/theme.css
+++ b/assets/css/base/theme.css
@@ -1,0 +1,11 @@
+:root {
+  --clr-bg:     #0d1117;
+  --clr-card:   #161b22;
+  --clr-text:   #e0e0e0;
+  --clr-primary:#ffd54f;
+  --clr-accent: #4fc3f7;
+  --radius-lg:  1rem;
+  --spc-1:      .25rem;
+  --spc-2:      .5rem;
+  --spc-4:      1rem;
+}

--- a/assets/css/step1_manual.css
+++ b/assets/css/step1_manual.css
@@ -1,4 +1,5 @@
 /* File: assets/css/step1_manual.css */
+@import url('base/theme.css');
 
 /* Estilo v6.0 trapezoidal, adaptado al stepper azul oscuro */
 
@@ -15,9 +16,9 @@
 }
 
 .facet-header {
-  background: #1e293b;
-  border-bottom: 1px solid #334155;
-  color: #cbd5e1;
+  background: var(--clr-card);
+  border-bottom: 1px solid var(--clr-accent);
+  color: var(--clr-text);
   cursor: pointer;
   font-size: .85rem;
   font-weight: 600;
@@ -25,9 +26,9 @@
 }
 
 .facet-body {
-  background: #0f172a;
-  border-left: 1px solid #334155;
-  border-right: 1px solid #334155;
+  background: var(--clr-bg);
+  border-left: 1px solid var(--clr-accent);
+  border-right: 1px solid var(--clr-accent);
   display: none;
   max-height: 220px;
   overflow-y: auto;
@@ -39,7 +40,7 @@
 }
 
 .facet-body label {
-  color: #cbd5e1;
+  color: var(--clr-text);
   display: block;
   font-size: .8rem;
   margin-bottom: 2px;
@@ -47,9 +48,9 @@
 }
 
 .facet-search {
-  background: #1e293b;
-  border: 1px solid #334155;
-  color: #cbd5e1;
+  background: var(--clr-card);
+  border: 1px solid var(--clr-accent);
+  color: var(--clr-text);
   font-size: 0.75rem;
   margin-bottom: .25rem;
   width: 100%;

--- a/assets/css/step6.css
+++ b/assets/css/step6.css
@@ -1,3 +1,4 @@
+@import url('base/theme.css');
 /**
  * Step 6 CSS – Ultra-Responsive & Debuggable styles
  * -----------------------------------------------

--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -1,11 +1,12 @@
 /* wizard/assets/css/wizard.css */
+@import url('base/theme.css');
 
 /* ────────────────────────────────────────────────────────────────
    GENERAL
    ──────────────────────────────────────────────────────────────── */
 body {
-  background: #0b1e2d;              /* tono azul-oscuro global   */
-  color: #dceefb;                   /* texto casi blanco-celeste */
+  background: var(--clr-bg);        /* fondo global */
+  color: var(--clr-text);           /* texto principal */
   font-family: 'Segoe UI', Roboto, sans-serif; /* tipografía base */
   margin: 0;                        /* quitamos margen browser   */
   padding: 0;                       /* …y padding por defecto    */
@@ -13,7 +14,7 @@ body {
 
 /* Contenedor del stepper (barra de pasos) */
 .stepper-container {
-  background: #0f172a;              /* fondo azul más oscuro     */
+  background: var(--clr-card);      /* fondo barra de pasos */
   overflow-x: auto;                 /* scroll horizontal móvil   */
   padding: 0;                       /* sin padding extra         */
   position: relative;               /* base para ::after/etc.    */
@@ -32,7 +33,7 @@ body {
 }
 
 .stepper li {
-  background: #0f172a;              /* mismo fondo contenedor    */
+  background: var(--clr-card);      /* igual al contenedor       */
   border-right: 1px solid rgb(255 255 255 / 10%); /* línea divisoria */
   clip-path: polygon(10px 0, 100% 0, calc(100% - 10px) 100%, 0% 100%);
   color: #64748b;                   /* gris-azulado apagado      */
@@ -58,7 +59,7 @@ body {
 /* estado completado o activo */
 .stepper li.done,
 .stepper li.active {
-  background: #1e293b;              /* fondo azul intermedio     */
+  background: var(--clr-bg);        /* fondo activo */
   color: #fff;                   /* texto blanco              */
   z-index: 2;                       /* por encima de inactivos   */
 }
@@ -67,7 +68,7 @@ body {
 .stepper li.active::before,
 .stepper li.done::before {
   animation: fill-line-left .6s ease-in forwards; /* efecto de llenado */
-  background: #0ea5e9;              /* azul brillante            */
+  background: var(--clr-accent);    /* azul brillante            */
   content: "";
   height: 4px;                      /* grosor de la barra        */ left: 0;
   position: absolute;
@@ -95,8 +96,8 @@ body {
    CONTENEDOR CENTRAL
    ──────────────────────────────────────────────────────────────── */
 .wizard-body {
-  background: #132330;              /* caja azul oscuro          */
-  border: 1px solid #264b63;        /* contorno sutil            */
+  background: var(--clr-card);      /* caja azul oscuro          */
+  border: 1px solid var(--clr-accent); /* contorno sutil        */
   border-radius: .75rem;            /* bordes redondeados        */
   box-shadow: 0 0 24px rgb(0 0 0 / 50%); /* sombra envolvente      */
   margin: 3rem auto;                /* centrado y margen sup.    */

--- a/assets/js/stepper.js
+++ b/assets/js/stepper.js
@@ -1,4 +1,5 @@
-/* global feather, bootstrap */
+import { createIcons } from 'lucide';
+/* global bootstrap */
 (() => {
   'use strict';
 
@@ -93,8 +94,8 @@
         stepHolder.innerHTML = html;
         runStepScripts(stepHolder);
 
-        // Inicializadores JS globales (Feather, Bootstrap tooltips)
-        if (window.feather) feather.replace();
+        // Inicializadores JS globales (Lucide, Bootstrap tooltips)
+        if (typeof createIcons === 'function') createIcons();
         if (window.bootstrap && bootstrap.Tooltip) {
           document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
             new bootstrap.Tooltip(el);
@@ -208,5 +209,6 @@
   if (!localStorage.getItem(LS_KEY)) localStorage.setItem(LS_KEY, 1);
   renderBar(getProg());
   loadStep(getProg());
+  createIcons();
 
 })();

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,0 +1,35 @@
+# Guía de Estilo Wizard CNC
+
+Esta refactorización unifica la apariencia del asistente.
+
+## Paleta
+- **Fondo** `#0d1117`
+- **Cards** `#161b22`
+- **Texto** `#e0e0e0`
+- **Primario** `#ffd54f`
+- **Acento** `#4fc3f7`
+
+Todas las hojas deben importar `assets/css/base/theme.css` y usar las variables CSS.
+
+## Tipografía
+Utilizamos `Segoe UI`, `Roboto`, `sans-serif`. No declarar fuentes extras.
+
+## Espaciado
+- `var(--spc-1)` = 4 px
+- `var(--spc-2)` = 8 px
+- `var(--spc-4)` = 16 px
+
+## Iconografía
+Se emplea **Lucide** mediante CDN ESModule:
+```html
+<script type="module" crossorigin src="https://cdn.jsdelivr.net/npm/lucide@latest/+esm"></script>
+```
+Los íconos se insertan con `<i data-lucide="nombre"></i>`.
+
+## Jerarquía de títulos
+- `<h1>` único oculto en `layout_wizard.php`.
+- `<h2>` para título de cada paso.
+- `<h3>` para subtítulos internos.
+
+## Naming
+Clases en inglés y en minúsculas con guiones (`btn-next`, `tool-image`).

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -9,6 +9,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Wizard CNC</title>
   <link rel="stylesheet" href="assets/css/wizard.css">
+  <script type="module" crossorigin
+          src="https://cdn.jsdelivr.net/npm/lucide@latest/+esm"></script>
 </head>
 <body>
 
@@ -22,6 +24,8 @@
       <?php endforeach; ?>
     </ul>
   </nav>
+
+  <h1 class="visually-hidden">Asistente CNC</h1>
 
   <!-- Botón reset -->
   <div style="text-align:right; padding:.5rem 1rem;">
@@ -45,10 +49,8 @@
     window.csrfToken = '<?= htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8') ?>';
   </script>
   <?php endif; ?>
-  <script src="assets/js/stepper.js" defer></script>
+  <script type="module" src="assets/js/stepper.js"></script>
   <script src="assets/js/dashboard.js" defer></script>
-<link rel="stylesheet" href="assets/css/wizard.css">
-<link rel="stylesheet" href="assets/css/step6.css"><!-- <---- AGREGALO ACÁ -->
 
 </body>
 </html>

--- a/views/select_mode.php
+++ b/views/select_mode.php
@@ -40,7 +40,8 @@
     <button class="btn btn-primary btn-lg mt-4">Continuar</button>
   </form>
 </main>
-<script src="https://unpkg.com/lucide@latest"></script>
-<script>lucide.createIcons();</script>
+<script type="module" crossorigin
+        src="https://cdn.jsdelivr.net/npm/lucide@latest/+esm"></script>
+<script type="module">import {createIcons} from 'https://cdn.jsdelivr.net/npm/lucide@latest/+esm';createIcons();</script>
 </body>
 </html>

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -151,12 +151,12 @@ if($tool){
 <body class="bg-dark text-white">
 
 <div class="container py-4">
-  <h2 class="step-title"><i class="bi bi-tools"></i> Paso 4 – Confirmar herramienta</h2>
+  <h2 class="step-title"><i data-lucide="wrench"></i> Paso 4 – Confirmar herramienta</h2>
   <p class="step-desc">Verificá la fresa sugerida antes de continuar.</p>
 
   <?php if ($error): ?>
       <div class="alert alert-danger mt-3">
-        <i class="bi bi-exclamation-triangle"></i> <?= htmlspecialchars($error) ?>
+        <i data-lucide="alert-triangle"></i> <?= htmlspecialchars($error) ?>
       </div>
 
   <?php else: ?>

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -153,7 +153,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <main class="container py-4" data-debug="step1">
       <div class="d-flex justify-content-between align-items-center mb-4">
         <div>
-          <h2 class="step-title"><i class="bi bi-box-seam"></i> Paso 1 – Explorador de fresas</h2>
+          <h2 class="step-title"><i data-lucide="box"></i> Paso 1 – Explorador de fresas</h2>
           <p class="step-desc">Elegí la herramienta inicial para el trabajo.</p>
         </div>
         <img src="/wizard-stepper_git/assets/img/logo_nexgen.png"
@@ -167,7 +167,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <aside class="col-md-3 sidebar">
           <div class="card h-100 shadow-sm">
             <div class="card-header bg-primary text-white py-2">
-              <i class="bi bi-funnel"></i> Filtros
+              <i data-lucide="filter"></i> Filtros
             </div>
             <div id="facetBox"></div>
             <div id="brandWarning" class="alert alert-warning m-0 py-1" hidden>
@@ -180,7 +180,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <main class="col-md-9">
           <div class="input-group mb-2">
             <span class="input-group-text">
-              <i class="bi bi-search"></i>
+              <i data-lucide="search"></i>
             </span>
             <input id="qBox"
                    class="form-control"

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -123,12 +123,12 @@ if ($tool) {
 <link rel="stylesheet" href="assets/css/step2_manual.css">
 
 <div class="container py-4">
-  <h2 class="step-title"><i class="bi bi-tools"></i> Paso 2 – Confirmar herramienta</h2>
+  <h2 class="step-title"><i data-lucide="wrench"></i> Paso 2 – Confirmar herramienta</h2>
   <p class="step-desc">Revisá los datos de la fresa elegida.</p>
 
   <?php if ($error): ?>
       <div class="alert alert-danger mt-3">
-        <i class="bi bi-exclamation-triangle"></i> <?= htmlspecialchars($error) ?>
+        <i data-lucide="alert-triangle"></i> <?= htmlspecialchars($error) ?>
       </div>
       <!-- Botón eliminado por nuevo flujo sin regreso -->
 

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -204,8 +204,6 @@ $cssBootstrapRel = file_exists($root . 'assets/css/bootstrap.min.css')
     ? '/wizard-stepper_git/assets/css/bootstrap.min.css' : '';
 $bootstrapJsRel  = file_exists($root . 'assets/js/bootstrap.bundle.min.js')
     ? '/wizard-stepper_git/assets/js/bootstrap.bundle.min.js' : '';
-$featherLocal    = $root . 'node_modules/feather-icons/dist/feather.min.js';
-$cdnFeather      = 'https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js';
 $chartJsLocal    = $root . 'node_modules/chart.js/dist/chart.umd.min.js';
 $cdnChartJs      = 'https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js';
 $countUpLocal    = $root . 'node_modules/countup.js/dist/countUp.umd.js';
@@ -219,7 +217,6 @@ $step6JsRel      = file_exists($root . 'assets/js/step6.js')
 $assetErrors = [];
 if (!$cssBootstrapRel)             $assetErrors[] = 'Bootstrap CSS no encontrado localmente.';
 if (!$bootstrapJsRel)               $assetErrors[] = 'Bootstrap JS no encontrado localmente.';
-if (!file_exists($featherLocal))    $assetErrors[] = 'Feather Icons JS faltante.';
 if (!file_exists($chartJsLocal))    $assetErrors[] = 'Chart.js faltante.';
 if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 ?>
@@ -233,6 +230,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
   <title>Datos de corte – Paso 6</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step6.css">
+  <script type="module" crossorigin src="https://cdn.jsdelivr.net/npm/lucide@latest/+esm"></script>
   
 </head>
 <body>
@@ -605,7 +603,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
               <ul class="notes-list mb-0">
                 <?php foreach ($notesArray as $note): ?>
                   <li class="mb-2 d-flex align-items-start">
-                    <i data-feather="file-text" class="me-2"></i>
+                    <i data-lucide="file-text" class="me-2"></i>
                     <div><?= htmlspecialchars($note, ENT_QUOTES) ?></div>
                   </li>
                 <?php endforeach; ?>
@@ -633,6 +631,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js"></script>
 <script src="/wizard-stepper_git/assets/js/step6.js"></script>
 <script>
+  if (window.createIcons) createIcons();
   window.addEventListener('pageshow', (e) => {
     if (e.persisted) {
       window.location.reload();


### PR DESCRIPTION
## Summary
- add global theme variables and style guide
- update layout and steps to use Lucide icons
- load icons via CDN ESModules
- convert stepper.js to an ES module
- document testing instructions

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852f7ec321c832c8e32a7a86a895ffc