### PR TITLE
Remove closing PHP tag

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -27,4 +27,3 @@ function respond_json($data) {
 function session_get(string $key) {
     return $_SESSION[$key] ?? null;
 }
-?>


### PR DESCRIPTION
## Summary
- remove closing PHP tag from `includes/functions.php`

## Testing
- `php -l includes/functions.php`

------
https://chatgpt.com/codex/tasks/task_e_6853090c5688832cb1c8461ccf0ef850