### PR TITLE
Refactor security headers into reusable helper

### DIFF
--- a/ajax/tools_scroll.php
+++ b/ajax/tools_scroll.php
@@ -6,13 +6,7 @@ use PDO;
 require_once __DIR__ . '/../src/Utils/Session.php';
 require_once __DIR__ . '/../includes/db.php';
 
-header('Content-Type: application/json; charset=UTF-8');
-header('Strict-Transport-Security: max-age=31536000; includeSubDomains; preload');
-header('X-Frame-Options: DENY');
-header('X-Content-Type-Options: nosniff');
-header('X-XSS-Protection: 1; mode=block');
-header('Referrer-Policy: no-referrer');
-header('Permissions-Policy: geolocation=(), microphone=()');
+sendSecurityHeaders('application/json; charset=UTF-8', 31536000, true);
 header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');

--- a/index.php
+++ b/index.php
@@ -42,13 +42,7 @@ require_once __DIR__ . '/src/Utils/Session.php';
 // -------------------------------------------
 // [B] CABECERAS DE SEGURIDAD HTTP
 // -------------------------------------------
-header('Content-Type: text/html; charset=UTF-8');
-header('Strict-Transport-Security: max-age=63072000; includeSubDomains; preload');
-header('X-Frame-Options: DENY');
-header('X-Content-Type-Options: nosniff');
-header('X-XSS-Protection: 1; mode=block');
-header('Referrer-Policy: no-referrer');
-header('Permissions-Policy: geolocation=(), microphone=()');
+sendSecurityHeaders('text/html; charset=UTF-8', 63072000, true);
 
 // -------------------------------------------
 // [C] INICIO DE SESIÓN SEGURA

--- a/public/load-step.php
+++ b/public/load-step.php
@@ -10,13 +10,7 @@ require_once __DIR__ . '/../src/Utils/Session.php';
 // ─────────────────────────────────────────────────────────────
 // [1] CABECERAS DE SEGURIDAD Y NO-CACHING
 // ─────────────────────────────────────────────────────────────
-header('Content-Type: text/html; charset=UTF-8');
-header('Strict-Transport-Security: max-age=63072000; includeSubDomains; preload');
-header('X-Frame-Options: DENY');
-header('X-Content-Type-Options: nosniff');
-header('X-XSS-Protection: 1; mode=block');
-header('Referrer-Policy: no-referrer');
-header('Permissions-Policy: geolocation=(), microphone=()');
+sendSecurityHeaders('text/html; charset=UTF-8', 63072000, true);
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');
 

--- a/public/reset.php
+++ b/public/reset.php
@@ -35,17 +35,12 @@ if (!function_exists('dbg')) {
     }
 }
 dbg('🔧 reset.php iniciado');
+require_once __DIR__ . '/../src/Utils/Session.php';
 
 // -------------------------------------------
 // [2] CABECERAS DE SEGURIDAD Y NO-CACHING
 // -------------------------------------------
-header('Content-Type: text/html; charset=UTF-8');
-header('Strict-Transport-Security: max-age=63072000; includeSubDomains; preload');
-header('X-Frame-Options: DENY');
-header('X-Content-Type-Options: nosniff');
-header('X-XSS-Protection: 1; mode=block');
-header('Referrer-Policy: no-referrer');
-header('Permissions-Policy: geolocation=(), microphone=()');
+sendSecurityHeaders('text/html; charset=UTF-8', 63072000, true);
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');
 

--- a/src/Utils/Session.php
+++ b/src/Utils/Session.php
@@ -55,3 +55,27 @@ if (!function_exists('validateCsrfToken')) {
         return hash_equals($_SESSION['csrf_token'], $token);
     }
 }
+
+if (!function_exists('sendSecurityHeaders')) {
+    /**
+     * Sends a common set of security headers.
+     *
+     * @param string $contentType      MIME type for the response.
+     * @param int    $hstsMaxAge       Max-age for the Strict-Transport-Security header.
+     * @param bool   $xssProtection    Whether to send the X-XSS-Protection header.
+     *
+     * @return void
+     */
+    function sendSecurityHeaders(string $contentType = 'text/html; charset=UTF-8', int $hstsMaxAge = 31536000, bool $xssProtection = false): void
+    {
+        header('Content-Type: ' . $contentType);
+        header('Strict-Transport-Security: max-age=' . $hstsMaxAge . '; includeSubDomains; preload');
+        header('X-Frame-Options: DENY');
+        header('X-Content-Type-Options: nosniff');
+        if ($xssProtection) {
+            header('X-XSS-Protection: 1; mode=block');
+        }
+        header('Referrer-Policy: no-referrer');
+        header('Permissions-Policy: geolocation=(), microphone=()');
+    }
+}

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../../../src/Utils/Session.php';
 /**
  * File: C:\xampp\htdocs\wizard-stepper_git\views\steps\auto\step1.php
  *
@@ -16,12 +17,7 @@ declare(strict_types=1);
 //
 // [A] Cabeceras de seguridad / anti-caching
 //
-header('Content-Type: text/html; charset=UTF-8');
-header("Strict-Transport-Security: max-age=31536000; includeSubDomains; preload");
-header("X-Frame-Options: DENY");
-header("X-Content-Type-Options: nosniff");
-header("Referrer-Policy: no-referrer");
-header("Permissions-Policy: geolocation=(), microphone=()");
+sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
 header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../../../src/Utils/Session.php';
 /**
  * File: step2.php
  * ---------------------------------------------------------------
@@ -14,12 +15,7 @@ declare(strict_types=1);
 // -------------------------------------------
 // [A] Cabeceras de seguridad y no‐caching
 // -------------------------------------------
-header('Content-Type: text/html; charset=UTF-8');
-header("Strict-Transport-Security: max-age=31536000; includeSubDomains; preload");
-header("X-Frame-Options: DENY");
-header("X-Content-Type-Options: nosniff");
-header("Referrer-Policy: no-referrer");
-header("Permissions-Policy: geolocation=(), microphone=()");
+sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
 header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../../../src/Utils/Session.php';
 /**
  * File: C:\xampp\htdocs\wizard-stepper_git\views\steps\auto\step4.php
  *
@@ -12,12 +13,7 @@ declare(strict_types=1);
 // ──────────────────────────────────────────────────────────────
 // [A] Cabeceras de seguridad / anti-caching
 // ──────────────────────────────────────────────────────────────
-header('Content-Type: text/html; charset=UTF-8');
-header("Strict-Transport-Security: max-age=31536000; includeSubDomains; preload");
-header("X-Frame-Options: DENY");
-header("X-Content-Type-Options: nosniff");
-header("Referrer-Policy: no-referrer");
-header("Permissions-Policy: geolocation=(), microphone=()");
+sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
 header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -6,6 +6,7 @@
  */
 
 declare(strict_types=1);
+require_once __DIR__ . '/../../../src/Utils/Session.php';
 
 // ──────────────── 1) Sesión y configuración segura ──────────────────
 if (session_status() !== PHP_SESSION_ACTIVE) {
@@ -17,12 +18,7 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 }
 
 // ──────────────── Cabeceras de seguridad ────────────────────────────
-header('Content-Type: text/html; charset=UTF-8');
-header("Strict-Transport-Security: max-age=31536000; includeSubDomains; preload");
-header("X-Frame-Options: DENY");
-header("X-Content-Type-Options: nosniff");
-header("Referrer-Policy: no-referrer");
-header("Permissions-Policy: geolocation=(), microphone=()");
+sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
 $nonce = base64_encode(random_bytes(16));

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../../../src/Utils/Session.php';
 /**
  * File: step3.php
  * ------------------------------------------------------------------
@@ -14,12 +15,7 @@ declare(strict_types=1);
 /* ──────────────────────────────────────────────────────
  * [A]  Cabeceras de seguridad & anti-cache
  * ──────────────────────────────────────────────────── */
-header('Content-Type: text/html; charset=UTF-8');
-header("Strict-Transport-Security: max-age=31536000; includeSubDomains; preload");
-header("X-Frame-Options: DENY");
-header("X-Content-Type-Options: nosniff");
-header("Referrer-Policy: no-referrer");
-header("Permissions-Policy: geolocation=(), microphone=()");
+sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
 header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../../../src/Utils/Session.php';
 /**
  * File: views/steps/manual/step4.php
  * Paso 4 (Manual) – Selección de madera compatible
@@ -9,12 +10,7 @@ declare(strict_types=1);
 //
 // [A] Cabeceras de seguridad / anti-caching
 //
-header('Content-Type: text/html; charset=UTF-8');
-header("Strict-Transport-Security: max-age=31536000; includeSubDomains; preload");
-header("X-Frame-Options: DENY");
-header("X-Content-Type-Options: nosniff");
-header("Referrer-Policy: no-referrer");
-header("Permissions-Policy: geolocation=(), microphone=()");
+sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
 header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;");

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -10,15 +10,11 @@ use App\Controller\ExpertResultController;
 // Si se abre en el navegador directamente → la constante NO existe
 // ──────────────────────────────────────────────────────────────
 $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
+require_once __DIR__ . '/../../src/Utils/Session.php';
 
 // [A] CABECERAS DE SEGURIDAD Y NO-CACHING (solo si NO embebido)
 if (!$embedded) {
-    header('Content-Type: text/html; charset=UTF-8');
-    header('Strict-Transport-Security: max-age=31536000; includeSubDomains; preload');
-    header('X-Frame-Options: DENY');
-    header('X-Content-Type-Options: nosniff');
-    header('Referrer-Policy: no-referrer');
-    header('Permissions-Policy: geolocation=(), microphone=()');
+    sendSecurityHeaders('text/html; charset=UTF-8');
     header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
     header('Pragma: no-cache');
     header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';");


### PR DESCRIPTION
## Summary
- add `sendSecurityHeaders()` helper
- reuse helper across PHP files
- include helper file where needed

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530a6da424832cb74cab22e052f048