### PR TITLE
Add responsive logo area to wizard stepper

### DIFF
--- a/assets/css/stepper.css
+++ b/assets/css/stepper.css
@@ -1,0 +1,31 @@
+.stepper-header {
+  background: var(--bs-body-bg);
+  border-bottom: 1px solid var(--bs-border-color);
+  padding: 0.5rem 1rem;
+}
+
+.logo-stepper {
+  height: auto;
+  margin-right: 1rem;
+  width: 80px;
+}
+
+.stepper-bar {
+  align-items: center;
+  display: flex;
+}
+
+/* Responsivo: ocultar logo en pantallas <768px */
+@media (width <= 767.98px) {
+  .logo-stepper {
+    display: none !important;
+  }
+
+  .stepper-header {
+    justify-content: center;
+  }
+
+  .stepper-bar {
+    width: 100%;
+  }
+}

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -9,19 +9,25 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Wizard CNC</title>
   <link rel="stylesheet" href="assets/css/wizard.css">
+  <link rel="stylesheet" href="assets/css/stepper.css">
 </head>
 <body>
 
   <!-- Barra de pasos -->
-  <nav class="stepper-container">
-    <ul class="stepper">
-      <?php foreach ($flow as $n): ?>
-        <li
-          data-step="<?= $n ?>"
-          data-label="<?= htmlspecialchars($labels[$n], ENT_QUOTES) ?>"></li>
-      <?php endforeach; ?>
-    </ul>
-  </nav>
+  <div class="stepper-header d-flex align-items-center">
+    <img src="assets/img/logos/logo_stepper.png" alt="Logo Stepper" class="logo-stepper">
+    <div class="stepper-bar flex-grow-1">
+      <nav class="stepper-container">
+        <ul class="stepper">
+          <?php foreach ($flow as $n): ?>
+            <li
+              data-step="<?= $n ?>"
+              data-label="<?= htmlspecialchars($labels[$n], ENT_QUOTES) ?>"></li>
+          <?php endforeach; ?>
+        </ul>
+      </nav>
+    </div>
+  </div>
 
   <!-- Botón reset -->
   <div style="text-align:right; padding:.5rem 1rem;">


### PR DESCRIPTION
## Summary
- add new `assets/css/stepper.css` with responsive header styles
- include the new stylesheet in `layout_wizard.php`
- wrap the stepper in `.stepper-header` and include the logo

## Testing
- `npx stylelint assets/css/stepper.css --quiet`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685310adfb08832cb80e1f22a13ce220