### PR TITLE
Fix stepper header layout

### DIFF
--- a/assets/css/stepper.css
+++ b/assets/css/stepper.css
@@ -1,18 +1,25 @@
 .stepper-header {
-  background: var(--bs-body-bg);
-  border-bottom: 1px solid var(--bs-border-color);
-  padding: 0.5rem 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 1050;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background-color: var(--bs-dark);
+  padding: 0;
+  margin: 0;
+  border: none;
 }
 
 .logo-stepper {
+  width: 120px;
   height: auto;
   margin-right: 1rem;
-  width: 80px;
 }
 
 .stepper-bar {
-  align-items: center;
   display: flex;
+  flex-wrap: nowrap;
 }
 
 /* Responsivo: ocultar logo en pantallas <768px */
@@ -25,7 +32,4 @@
     justify-content: center;
   }
 
-  .stepper-bar {
-    width: 100%;
-  }
 }

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -14,20 +14,21 @@
 <body>
 
   <!-- Barra de pasos -->
-  <div class="stepper-header d-flex align-items-center">
-    <img src="assets/img/logos/logo_stepper.png" alt="Logo Stepper" class="logo-stepper">
-    <div class="stepper-bar flex-grow-1">
-      <nav class="stepper-container">
-        <ul class="stepper">
-          <?php foreach ($flow as $n): ?>
-            <li
-              data-step="<?= $n ?>"
-              data-label="<?= htmlspecialchars($labels[$n], ENT_QUOTES) ?>"></li>
-          <?php endforeach; ?>
-        </ul>
-      </nav>
-    </div>
-  </div>
+  <header class="stepper-header d-flex align-items-center">
+    <img
+      src="assets/img/logos/logo_stepper.png"
+      alt="Logo Stepper"
+      class="logo-stepper">
+    <nav class="stepper-bar flex-grow-1">
+      <ul class="stepper">
+        <?php foreach ($flow as $n): ?>
+          <li
+            data-step="<?= $n ?>"
+            data-label="<?= htmlspecialchars($labels[$n], ENT_QUOTES) ?>"></li>
+        <?php endforeach; ?>
+      </ul>
+    </nav>
+  </header>
 
   <!-- Botón reset -->
   <div style="text-align:right; padding:.5rem 1rem;">


### PR DESCRIPTION
## Summary
- simplify stepper markup using `<header>` and `<nav>`
- make the stepper header sticky and enlarge the logo
- adjust responsive rule to hide the logo on small screens

## Testing
- `npm run lint` *(fails: Missing script)*
- `composer run-script lint` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685315d9e860832cad6d0ccffe6bb7ac