### PR TITLE
Use noUiSlider for step 6 sliders

### DIFF
--- a/assets/js/step7_expert_result.js
+++ b/assets/js/step7_expert_result.js
@@ -14,6 +14,8 @@ function initExpertResult(P) {
     return;
   }
 
+  const { noUiSlider } = window;
+
   const required = ['vc0', 'fzMinEff', 'fzMaxEff', 'D', 'Z', 'thickness', 'ae', 'rpmMin', 'rpmMax', 'frMax', 'Kc11', 'mc', 'eta', 'strategy'];
   const missing = required.filter(k => P[k] === undefined);
   if (missing.length > 0) {
@@ -77,15 +79,35 @@ function initExpertResult(P) {
   const mmrBase = (apBase * aeReal * feedBase) / 1000;
 
   function initSliders() {
-    vcS.step = 0.1;
-    vcS.min = +(vcBase * 0.75).toFixed(1);
-    vcS.max = +(vcBase * 1.25).toFixed(1);
-    vcS.value = vcBase;
+    noUiSlider.create(vcS, {
+      start: [vcBase],
+      connect: [true, false],
+      range: {
+        min: +(vcBase * 0.75).toFixed(1),
+        max: +(vcBase * 1.25).toFixed(1)
+      },
+      step: 0.1,
+      tooltips: true,
+      format: {
+        to: v => (+v).toFixed(1),
+        from: v => parseFloat(v)
+      }
+    });
     vcV.textContent = `${vcBase} m/min`;
-    vcMinL.textContent = `${vcS.min} m/min`;
-    vcMaxL.textContent = `${vcS.max} m/min`;
+    vcMinL.textContent = `${(vcBase * 0.75).toFixed(1)} m/min`;
+    vcMaxL.textContent = `${(vcBase * 1.25).toFixed(1)} m/min`;
 
-    fzS.step = 0.0001;
+    noUiSlider.create(fzS, {
+      start: [fzMin0],
+      connect: [true, false],
+      range: { min: fzMin0, max: fzMax0 },
+      step: 0.0001,
+      tooltips: true,
+      format: {
+        to: v => (+v).toFixed(4),
+        from: v => parseFloat(v)
+      }
+    });
 
     passS.min = 1;
     passS.max = 10;
@@ -118,28 +140,28 @@ function initExpertResult(P) {
     const apAct = apBase / EP;
     const minFz = +(fzMin0 * apBase / apAct * seg).toFixed(4);
     const maxFz = +(fzMax0 * apBase / apAct * seg).toFixed(4);
-    fzS.min = minFz;
-    fzS.max = maxFz;
+    fzS.noUiSlider.updateOptions({ range: { min: minFz, max: maxFz } });
     fzMinL.textContent = `${minFz} mm`;
     fzMaxL.textContent = `${maxFz} mm`;
-    const vc = +vcS.value;
+    const vc = +vcS.noUiSlider.get();
     const rpm = (vc * 1000) / (Math.PI * D);
     const fzIdeal = (mmrBase * 1000) / (apAct * aeReal * rpm * Z);
-    fzS.value = Math.min(Math.max(fzIdeal, minFz), maxFz).toFixed(4);
-    fzV.textContent = `${fzS.value} mm`;
+    const clamped = Math.min(Math.max(fzIdeal, minFz), maxFz).toFixed(4);
+    fzS.noUiSlider.set(clamped);
+    fzV.textContent = `${clamped} mm`;
   }
 
   function displayValues() {
-    vcV.textContent = `${vcS.value} m/min`;
-    fzV.textContent = `${fzS.value} mm`;
+    vcV.textContent = `${vcS.noUiSlider.get()} m/min`;
+    fzV.textContent = `${fzS.noUiSlider.get()} mm`;
     aeV.textContent = `${aeS.value} mm`;
     const paso = apBase / +passS.value;
     passV.textContent = `${passS.value} pasada${passS.value > 1 ? 's' : ''} de ${paso.toFixed(2)} mm`;
   }
 
   function calculateAll() {
-    const fz = +fzS.value,
-          vc = +vcS.value,
+    const fz = +fzS.noUiSlider.get(),
+          vc = +vcS.noUiSlider.get(),
           EP = +passS.value;
     const ap = apBase / EP;
     aeReal = +aeS.value;
@@ -184,8 +206,8 @@ function initExpertResult(P) {
     displayValues();
   }
 
-  vcS.addEventListener('input', calculateAll);
-  fzS.addEventListener('input', calculateAll);
+  vcS.noUiSlider.on('update', calculateAll);
+  fzS.noUiSlider.on('update', calculateAll);
   aeS.addEventListener('input', () => {
     aeReal = +aeS.value;
     aeV.textContent = `${aeReal} mm`;

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -10,6 +10,8 @@
   <title>Wizard CNC</title>
   <link rel="stylesheet" href="assets/css/wizard.css">
   <link rel="stylesheet" href="assets/css/stepper.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/15.7.0/nouislider.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/15.7.0/nouislider.min.js" defer integrity="sha384-..." crossorigin="anonymous" nonce="<?= $nonce ?? '' ?>"></script>
 </head>
 <body>
 

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -295,16 +295,14 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
           <div class="card-body p-4">
             <!-- fz -->
             <div class="mb-4 px-2">
-              <label for="sliderFz" class="form-label">fz (mm/tooth)</label>
-              <input
-                type="range"
-                id="sliderFz"
-                class="form-range"
-                min="<?= number_format($fzMinDb,4,'.','') ?>"
-                max="<?= number_format($fzMaxDb,4,'.','') ?>"
-                step="0.0001"
-                value="<?= number_format($baseFz,4,'.','') ?>"
-              >
+              <label for="fz_slider" class="form-label">fz (mm/tooth)</label>
+              <div
+                id="fz_slider"
+                data-min="<?= number_format($fzMinDb,4,'.','') ?>"
+                data-max="<?= number_format($fzMaxDb,4,'.','') ?>"
+                data-step="0.0001"
+                data-value="<?= number_format($baseFz,4,'.','') ?>"
+              ></div>
               <div class="text-end small text-secondary mt-1">
                 <span><?= number_format($fzMinDb,4,'.','') ?></span> –
                 <strong id="valFz"><?= number_format($baseFz,4,'.','') ?></strong> –
@@ -313,16 +311,14 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
             </div>
             <!-- Vc -->
             <div class="mb-4 px-2">
-              <label for="sliderVc" class="form-label">Vc (m/min)</label>
-              <input
-                type="range"
-                id="sliderVc"
-                class="form-range"
-                min="<?= number_format($vcMinDb,1,'.','') ?>"
-                max="<?= number_format($vcMaxDb,1,'.','') ?>"
-                step="0.1"
-                value="<?= number_format($baseVc,1,'.','') ?>"
-              >
+              <label for="vc_slider" class="form-label">Vc (m/min)</label>
+              <div
+                id="vc_slider"
+                data-min="<?= number_format($vcMinDb,1,'.','') ?>"
+                data-max="<?= number_format($vcMaxDb,1,'.','') ?>"
+                data-step="0.1"
+                data-value="<?= number_format($baseVc,1,'.','') ?>"
+              ></div>
               <div class="text-end small text-secondary mt-1">
                 <span><?= number_format($vcMinDb,1,'.','') ?></span> –
                 <strong id="valVc"><?= number_format($baseVc,1,'.','') ?></strong> –


### PR DESCRIPTION
## Summary
- include noUiSlider assets via CDN in the wizard layout
- switch Fz and Vc range inputs to `div` containers
- instantiate noUiSlider controls in the expert results script

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `composer validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531bbab954832c871a880b458f16ba