### PR TITLE
Fix sentinel size for infinite scroll

### DIFF
--- a/README_scroll_fix.md
+++ b/README_scroll_fix.md
@@ -6,6 +6,12 @@ El listado de herramientas en `step1.php` se cargaba usando un script inline que
 ## Solución
 Se movieron los scripts inline a un módulo externo `assets/js/step1_manual_hook.js`. El token CSRF ahora se expone mediante una etiqueta `<meta>` y es leído por los módulos. La CSP se actualizó para permitir únicamente scripts propios y uno firmado con `nonce`. Dentro de `step1_lazy.js` se ajustó la inicialización para que siempre cargue la primera página y se añadió un alto mínimo al *sentinel*.
 
+```css
+#sentinel {
+  min-height: 40px;
+}
+```
+
 ## Pasos para reproducir
 1. Abrir `step1.php` antes de aplicar el fix y observar en la consola del navegador errores CSP y que la lista no se carga.
 2. Con la actualización, recargar la página y verificar que el primer lote de fresas aparece automáticamente.

--- a/assets/css/step1_manual.css
+++ b/assets/css/step1_manual.css
@@ -127,3 +127,7 @@ h2.fw-bold {
   max-height: 70vh;
   overflow-y: auto;
 }
+
+#sentinel {
+  min-height: 40px;
+}


### PR DESCRIPTION
## Summary
- ensure sentinel has a minimum height for IntersectionObserver
- document sentinel style in README_scroll_fix

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm run lint` *(fails: missing script)*
- `composer run-script lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853196b1ea0832c8cda72d34a8a98aa