### PR TITLE
Improve step6 sliders with bubble, gradient and keyboard controls

### DIFF
--- a/assets/css/step6.css
+++ b/assets/css/step6.css
@@ -134,10 +134,15 @@ body {
   margin-bottom: 0.3rem;
 }
 
+.slider-wrap {
+  --val: 0;
+  --step-pct: 10;
+  position: relative;
+}
+
 input[type="range"].form-range {
   appearance: none;
-  background: var(--border-color);
-  border-radius: 3px;
+  background: none;
   cursor: pointer;
   height: 6px;
   width: 100%;
@@ -145,6 +150,10 @@ input[type="range"].form-range {
 
 input[type="range"].form-range:focus {
   outline: none;
+}
+
+input[type="range"].form-range:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 3px rgb(79 195 247 / 40%);
 }
 
 input[type="range"].form-range::-webkit-slider-thumb {
@@ -171,7 +180,17 @@ input[type="range"].form-range::-ms-thumb {
 input[type="range"].form-range::-webkit-slider-runnable-track,
 input[type="range"].form-range::-moz-range-track,
 input[type="range"].form-range::-ms-track {
-  background: var(--border-color);
+  background:
+    linear-gradient(to right,
+      var(--accent-color) 0%,
+      var(--accent-color) calc(var(--val) * 1%),
+      var(--border-color) calc(var(--val) * 1%),
+      var(--border-color) 100%)
+    no-repeat,
+    repeating-linear-gradient(to right,
+      transparent 0 calc(var(--step-pct) * 1% - 1px),
+      var(--accent-color-light) calc(var(--step-pct) * 1% - 1px) calc(var(--step-pct) * 1%));
+  background-size: 100% 100%, 100% 100%;
   border-radius: 3px;
   height: 6px;
 }
@@ -188,6 +207,28 @@ input[type="range"].form-range::-ms-track {
   top: -1.2rem;
   transform: translateX(-50%);
   white-space: nowrap;
+}
+
+.slider-bubble {
+  background: var(--accent-color);
+  border-radius: 4px;
+  color: var(--bg-body);
+  font-size: 0.75rem;
+  padding: 0.1rem 0.35rem;
+  position: absolute;
+  top: -1.6rem;
+  left: calc(var(--val) * 1%);
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+@keyframes shake {
+  0%,100% { transform: translateX(-50%) translateY(0); }
+  50% { transform: translateX(-50%) translateY(-2px); }
+}
+
+.slider-wrap input:active + .slider-bubble {
+  animation: shake 0.3s;
 }
 
 /* Valores slider */

--- a/assets/js/step7_expert_result.js
+++ b/assets/js/step7_expert_result.js
@@ -76,6 +76,43 @@ function initExpertResult(P) {
   const feedBase = rpmBase * fzMin0 * Z;
   const mmrBase = (apBase * aeReal * feedBase) / 1000;
 
+  function enhanceSlider(slider) {
+    const wrap = slider.closest('.slider-wrap');
+    if (!wrap) return;
+    const bubble = wrap.querySelector('.slider-bubble');
+    const min = parseFloat(slider.min || 0);
+    const max = parseFloat(slider.max || 1);
+    const step = parseFloat(slider.step || 1);
+
+    function update(val) {
+      const pct = ((val - min) / (max - min)) * 100;
+      wrap.style.setProperty('--val', pct);
+      if (bubble) bubble.textContent = parseFloat(val).toFixed(3);
+    }
+
+    slider.addEventListener('input', e => {
+      update(parseFloat(e.target.value));
+    });
+
+    slider.addEventListener('keydown', e => {
+      let delta = 0;
+      if (e.key === 'ArrowRight' || e.key === 'ArrowUp') delta = step;
+      else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') delta = -step;
+      else if (e.key === 'PageUp') delta = step * 10;
+      else if (e.key === 'PageDown') delta = -step * 10;
+      if (delta !== 0) {
+        e.preventDefault();
+        let newVal = parseFloat(slider.value) + delta;
+        newVal = Math.min(max, Math.max(min, newVal));
+        slider.value = newVal;
+        slider.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    });
+
+    wrap.style.setProperty('--step-pct', (step / (max - min)) * 100);
+    update(parseFloat(slider.value));
+  }
+
   function initSliders() {
     vcS.step = 0.1;
     vcS.min = +(vcBase * 0.75).toFixed(1);
@@ -111,6 +148,8 @@ function initExpertResult(P) {
     aeReal = +aeS.value;
     updateFzRange();
     calculateAll();
+    enhanceSlider(fzS);
+    enhanceSlider(vcS);
   }
 
   function updateFzRange() {

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -296,15 +296,18 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
             <!-- fz -->
             <div class="mb-4 px-2">
               <label for="sliderFz" class="form-label">fz (mm/tooth)</label>
-              <input
-                type="range"
-                id="sliderFz"
-                class="form-range"
-                min="<?= number_format($fzMinDb,4,'.','') ?>"
-                max="<?= number_format($fzMaxDb,4,'.','') ?>"
-                step="0.0001"
-                value="<?= number_format($baseFz,4,'.','') ?>"
-              >
+              <div class="slider-wrap">
+                <input
+                  type="range"
+                  id="sliderFz"
+                  class="form-range"
+                  min="<?= number_format($fzMinDb,4,'.','') ?>"
+                  max="<?= number_format($fzMaxDb,4,'.','') ?>"
+                  step="0.0001"
+                  value="<?= number_format($baseFz,4,'.','') ?>"
+                >
+                <span class="slider-bubble"></span>
+              </div>
               <div class="text-end small text-secondary mt-1">
                 <span><?= number_format($fzMinDb,4,'.','') ?></span> –
                 <strong id="valFz"><?= number_format($baseFz,4,'.','') ?></strong> –
@@ -314,15 +317,18 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
             <!-- Vc -->
             <div class="mb-4 px-2">
               <label for="sliderVc" class="form-label">Vc (m/min)</label>
-              <input
-                type="range"
-                id="sliderVc"
-                class="form-range"
-                min="<?= number_format($vcMinDb,1,'.','') ?>"
-                max="<?= number_format($vcMaxDb,1,'.','') ?>"
-                step="0.1"
-                value="<?= number_format($baseVc,1,'.','') ?>"
-              >
+              <div class="slider-wrap">
+                <input
+                  type="range"
+                  id="sliderVc"
+                  class="form-range"
+                  min="<?= number_format($vcMinDb,1,'.','') ?>"
+                  max="<?= number_format($vcMaxDb,1,'.','') ?>"
+                  step="0.1"
+                  value="<?= number_format($baseVc,1,'.','') ?>"
+                >
+                <span class="slider-bubble"></span>
+              </div>
               <div class="text-end small text-secondary mt-1">
                 <span><?= number_format($vcMinDb,1,'.','') ?></span> –
                 <strong id="valVc"><?= number_format($baseVc,1,'.','') ?></strong> –
@@ -334,15 +340,18 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
               <label for="sliderAe" class="form-label">
                 ae (mm) <small>(ancho de pasada)</small>
               </label>
-              <input
-                type="range"
-                id="sliderAe"
-                class="form-range"
-                min="0.1"
-                max="<?= number_format($diameterMb,1,'.','') ?>"
-                step="0.1"
-                value="<?= number_format($diameterMb*0.5,1,'.','') ?>"
-              >
+              <div class="slider-wrap">
+                <input
+                  type="range"
+                  id="sliderAe"
+                  class="form-range"
+                  min="0.1"
+                  max="<?= number_format($diameterMb,1,'.','') ?>"
+                  step="0.1"
+                  value="<?= number_format($diameterMb*0.5,1,'.','') ?>"
+                >
+                <span class="slider-bubble"></span>
+              </div>
               <div class="text-end small text-secondary mt-1">
                 <span>0.1</span> –
                 <strong id="valAe"><?= number_format($diameterMb*0.5,1,'.','') ?></strong> –
@@ -352,16 +361,19 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
             <!-- Pasadas -->
             <div class="mb-4 px-2">
               <label for="sliderPasadas" class="form-label">Pasadas</label>
-              <input
-                type="range"
-                id="sliderPasadas"
-                class="form-range"
-                min="1"
-                max="1"
-                step="1"
-                value="1"
-                data-thickness="<?= htmlspecialchars((string)$thickness, ENT_QUOTES) ?>"
-              >
+              <div class="slider-wrap">
+                <input
+                  type="range"
+                  id="sliderPasadas"
+                  class="form-range"
+                  min="1"
+                  max="1"
+                  step="1"
+                  value="1"
+                  data-thickness="<?= htmlspecialchars((string)$thickness, ENT_QUOTES) ?>"
+                >
+                <span class="slider-bubble"></span>
+              </div>
               <div id="textPasadasInfo" class="small text-secondary mt-1">
                 1 pasada de <?= number_format($thickness, 2) ?> mm
               </div>


### PR DESCRIPTION
## Summary
- wrap range inputs in `.slider-wrap` and add `.slider-bubble`
- style range tracks with CSS variables for gradient progress and pips
- animate bubbles with a shake effect
- enhance sliders via `enhanceSlider()` function and keyboard listeners

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531ea02438832cb07959247de61f53