### PR TITLE
Fix list-scroll container style

### DIFF
--- a/assets/css/step1_manual.css
+++ b/assets/css/step1_manual.css
@@ -124,10 +124,10 @@ h2.fw-bold {
   max-height: none !important;
 }
 .list-scroll-container {
-  max-height: 70vh;
+  max-height: 65vh; /* ajustá si hace falta */
   overflow-y: auto;
 }
 
 #sentinel {
-  min-height: 40px;
+  height: 1px;
 }


### PR DESCRIPTION
## Summary
- limit height for `.list-scroll-container` and enable vertical scroll
- shrink `#sentinel` height so observer can trigger at bottom

## Testing
- `npm run lint` *(fails: Missing script)*
- `composer run-script lint` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68531fc27680832cbf4450d90d8fb5b7