### PR TITLE
Reload lazy table on filter change

### DIFF
--- a/assets/js/step1_lazy.js
+++ b/assets/js/step1_lazy.js
@@ -75,6 +75,7 @@ export function initLazy() {
     loading = false;
     hasMore = true;
     tbody.innerHTML = "";
+    observer.disconnect();
     observer.observe(sentinel);
     loadPage();
   }

--- a/assets/js/step1_manual_browser.js
+++ b/assets/js/step1_manual_browser.js
@@ -91,12 +91,16 @@
   qBox.addEventListener('input', debounce(applyFilter,300));
 
   function applyFilter(){
+    tableBody.innerHTML='';
     if(!facetBox.querySelectorAll('input[name="brand"]:checked').length){
-      brandWarning.hidden=false; tableBody.innerHTML='';
-      return;
+      brandWarning.hidden=false;
+    } else {
+      brandWarning.hidden=true;
+      cargarTabla();
     }
-    brandWarning.hidden=true;
-    cargarTabla();
+    import('/wizard-stepper_git/assets/js/step1_lazy.js')
+      .then(m => m.initLazy())
+      .catch(console.error);
   }
 
   /* ========== AJAX → tools_ajax.php =============================== */


### PR DESCRIPTION
## Summary
- restart lazy table when filters change in manual browser
- ensure observer is disconnected before reattaching sentinel

## Testing
- `npm run lint` *(fails: Missing script)*
- `composer run-script lint` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68531fc6d094832cb968c3699bc9eff7