### PR TITLE
Align CSRF header

### DIFF
--- a/ajax/step_minimo_ajax.php
+++ b/ajax/step_minimo_ajax.php
@@ -18,11 +18,10 @@ header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 session_start();
 
 // 0. CSRF: validar token enviado en header X-CSRF-Token
-$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
-if (empty($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $csrfHeader)) {
+$token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+if (!hash_equals($_SESSION['csrf_token'], $token)) {
     http_response_code(403);
-    echo json_encode(['success' => false, 'error' => 'Token CSRF inválido']);
-    exit;
+    exit('CSRF fail');
 }
 
 // 1. Leer entrada JSON

--- a/ajax/tools_scroll.php
+++ b/ajax/tools_scroll.php
@@ -19,11 +19,10 @@ if (($_SESSION['wizard_state'] ?? '') !== 'wizard') {
     exit;
 }
 
-$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
-if (empty($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $csrfHeader)) {
+$token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+if (!hash_equals($_SESSION['csrf_token'], $token)) {
     http_response_code(403);
-    echo json_encode(['status' => 'error', 'message' => 'csrf']);
-    exit;
+    exit('CSRF fail');
 }
 
 if (isset($_SESSION['tools_permission']) && !$_SESSION['tools_permission']) {

--- a/public/export.php
+++ b/public/export.php
@@ -5,10 +5,10 @@ require_once __DIR__ . '/../includes/security.php';
 session_start();
 require_debug_mode();
 
-$token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? ($_GET['csrf_token'] ?? '');
-if (!validate_csrf_token($token)) {
+$token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+if (!hash_equals($_SESSION['csrf_token'], $token)) {
     http_response_code(403);
-    exit('Invalid CSRF token');
+    exit('CSRF fail');
 }
 
 header('Content-Type: text/plain');

--- a/public/export_json.php
+++ b/public/export_json.php
@@ -5,10 +5,10 @@ require_once __DIR__ . '/../includes/security.php';
 session_start();
 require_debug_mode();
 
-$token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? ($_GET['csrf_token'] ?? '');
-if (!validate_csrf_token($token)) {
+$token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+if (!hash_equals($_SESSION['csrf_token'], $token)) {
     http_response_code(403);
-    exit('Invalid CSRF token');
+    exit('CSRF fail');
 }
 
 header('Content-Type: application/json');

--- a/public/session-api.php
+++ b/public/session-api.php
@@ -5,10 +5,10 @@ require_once __DIR__ . '/../includes/security.php';
 session_start();
 require_debug_mode();
 
-$token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? ($_GET['csrf_token'] ?? '');
-if (!validate_csrf_token($token)) {
+$token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+if (!hash_equals($_SESSION['csrf_token'], $token)) {
     http_response_code(403);
-    exit('Invalid CSRF token');
+    exit('CSRF fail');
 }
 
 header('Content-Type: application/json; charset=utf-8');


### PR DESCRIPTION
## Summary
- unify CSRF header check across PHP scripts
- drop POST/GET fallbacks
- keep fetch calls using `X-CSRF-Token` header

## Testing
- `php -v`
- `apt-get install -y php`
- `php -S localhost:8000 >/tmp/server.log 2>&1 &` *(fails: DB driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_68531fcb2c30832c9b8176c021341357