### PR TITLE
Add infinite scroll on step 3

### DIFF
--- a/ajax/tools_scroll.php
+++ b/ajax/tools_scroll.php
@@ -33,21 +33,66 @@ if (isset($_SESSION['tools_permission']) && !$_SESSION['tools_permission']) {
 
 $page = filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) ?: 1;
 $pageSize = filter_input(INPUT_GET, 'page_size', FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 100]]) ?: 30;
-
 $offset = ($page - 1) * $pageSize;
+$mode = $_GET['mode'] ?? 'manual';
+
+$pdo = db();
+
+if ($mode === 'auto') {
+    $material_id = (int)($_SESSION['material_id'] ?? 0);
+    $strategy_id = (int)($_SESSION['strategy_id'] ?? 0);
+    if ($material_id <= 0 || $strategy_id <= 0) {
+        echo json_encode(['tools' => [], 'hasMore' => false]);
+        exit;
+    }
+
+    $toolTables = [
+        'tools_sgs'       => 'toolsmaterial_sgs',
+        'tools_maykestag' => 'toolsmaterial_maykestag',
+        'tools_schneider' => 'toolsmaterial_schneider',
+        'tools_generico'  => 'toolsmaterial_generico',
+    ];
+
+    $parts  = [];
+    $params = [];
+    foreach ($toolTables as $toolTbl => $matTbl) {
+        $parts[] = "(SELECT t.tool_id, s.code AS serie, b.name AS brand, t.tool_code, t.name, t.image, t.diameter_mm, t.shank_diameter_mm, t.flute_length_mm, t.cut_length_mm, t.flute_count, m.rating, '{$toolTbl}' AS source_table FROM {$toolTbl} AS t INNER JOIN {$matTbl} AS m ON t.tool_id = m.tool_id INNER JOIN series AS s ON t.series_id = s.id INNER JOIN brands AS b ON s.brand_id = b.id INNER JOIN toolstrategy AS ts ON ts.tool_id = t.tool_id AND ts.tool_table = '{$toolTbl}' WHERE m.material_id = ? AND ts.strategy_id = ? AND m.rating > 0)";
+        $params[] = $material_id;
+        $params[] = $strategy_id;
+    }
+
+    $sql = implode(' UNION ALL ', $parts) . ' ORDER BY rating DESC LIMIT :limit OFFSET :offset';
+    $stmt = $pdo->prepare($sql);
+    foreach ($params as $i => $val) {
+        $stmt->bindValue($i + 1, $val, PDO::PARAM_INT);
+    }
+    $stmt->bindValue(':limit', $pageSize, PDO::PARAM_INT);
+    $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+    $stmt->execute();
+    $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($data as &$row) {
+        $img = $row['image'] ?? '';
+        $row['img_url'] = $img !== '' ? '/wizard-stepper_git/' . ltrim((string)$img, '/') : '';
+    }
+    unset($row);
+
+    $hasMore = count($data) === $pageSize;
+
+    echo json_encode(['tools' => $data, 'hasMore' => $hasMore]);
+    exit;
+}
+
 $sql = 'SELECT * FROM tools_generico ORDER BY diameter_mm ASC LIMIT :limit OFFSET :offset';
 
 $key = 'tools_scroll_' . md5($sql . '|' . $page . '|' . $pageSize);
 $cacheAvailable = function_exists('apcu_fetch');
 $data = $cacheAvailable ? apcu_fetch($key, $hit) : false;
 if (!$cacheAvailable || !$hit) {
-    $pdo = db();
     $stmt = $pdo->prepare($sql);
     $stmt->bindValue(':limit', $pageSize, PDO::PARAM_INT);
     $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
     $stmt->execute();
     $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    // Compute image URLs for freshly fetched data
     foreach ($data as &$row) {
         $img = $row['image'] ?? '';
         $row['img_url'] = $img !== '' ? '/wizard-stepper_git/' . ltrim((string)$img, '/') : '';
@@ -56,7 +101,7 @@ if (!$cacheAvailable || !$hit) {
     if ($cacheAvailable) {
         apcu_store($key, $data, 60);
     }
-} else { // Ensure cached data also includes image URLs
+} else {
     foreach ($data as &$row) {
         if (!isset($row['img_url'])) {
             $img = $row['image'] ?? '';
@@ -64,7 +109,7 @@ if (!$cacheAvailable || !$hit) {
         }
     }
     unset($row);
-} // Fallback to direct query when APCu functions are missing
+}
 
 $hasMore = count($data) === $pageSize;
 

--- a/assets/css/steps/auto/step3.css
+++ b/assets/css/steps/auto/step3.css
@@ -56,3 +56,10 @@ h2 {
   background-color: #0d6efd;
   color: #fff;
 }
+#scrollContainer {
+  max-height: 65vh;
+  overflow-y: auto;
+}
+#sentinel {
+  height: 1px;
+}

--- a/assets/js/step3_lazy.js
+++ b/assets/js/step3_lazy.js
@@ -1,0 +1,23 @@
+import { BASE_URL } from './config.js';
+
+let observer;
+
+export function initLazy() {
+  const sentinel = document.getElementById('sentinel');
+  const scrollContainer = document.getElementById('scrollContainer');
+  if (!sentinel || !scrollContainer) return;
+
+  observer?.disconnect();
+  observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        if (window.fetchTools && typeof window.fetchTools === 'function') {
+          window.fetchTools(window.currentPage + 1);
+        }
+      }
+    });
+  }, { root: scrollContainer, rootMargin: '200px', threshold: 0.1 });
+
+  observer.observe(sentinel);
+}
+


### PR DESCRIPTION
## Summary
- support infinite scroll for tool listing in auto step 3
- add sentinel div and scroll container styling
- load additional pages through new module `step3_lazy.js`
- extend backend API to paginate when `mode=auto`

## Testing
- `npm run lint` *(fails: Missing script)*
- `composer run-script lint` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6853fddd0cac832cb6e6ca7df873a800