### PR TITLE
Apply feather icons to step titles

### DIFF
--- a/assets/css/step-common.css
+++ b/assets/css/step-common.css
@@ -47,10 +47,22 @@ body {
 }
 
 /* Títulos y descripciones de pasos */
+
+/* Encabezados uniformes de los pasos */
 .step-title {
-  color: #fff;
+  font-size: 1.5rem;
   font-weight: 600;
-  margin-bottom: 0.5rem;
+  color: #d1d1d1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.step-title i[data-feather] {
+  width: 24px;
+  height: 24px;
+  stroke: #17a2b8;
 }
 
 .step-desc {

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -54,7 +54,8 @@
     window.csrfToken = '<?= htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8') ?>';
   </script>
   <?php endif; ?>
-  <script src="node_modules/feather-icons/dist/feather.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
+  <script>feather.replace();</script>
   <script src="assets/js/stepper.js" defer></script>
   <script src="assets/js/dashboard.js" defer></script>
 <link rel="stylesheet" href="assets/css/wizard.css">

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -202,7 +202,7 @@ dbg('children', $children);
 <body>
   <main class="container py-4">
 
-  <h2 class="step-title">Paso 1 – Material y espesor</h2>
+  <h2 class="step-title"><i data-feather="layers"></i> Material y espesor</h2>
   <p class="step-desc">Seleccioná el material a mecanizar y su espesor.</p>
 
   <?php if (!empty($err)): ?>

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -186,7 +186,7 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
 <body>
   <main class="container py-4">
 
-  <h2 class="step-title">Paso 2 – Mecanizado y estrategia</h2>
+  <h2 class="step-title"><i data-feather="settings"></i> Mecanizado y estrategia</h2>
   <p class="step-desc">Elegí el tipo de mecanizado y la estrategia recomendada.</p>
 
   <?php if (!empty($errors)): ?>

--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -166,7 +166,7 @@ try {
 <body>
   <main class="container py-4">
 
-  <h2 class="step-title">Paso 3 – Herramientas compatibles</h2>
+  <h2 class="step-title"><i data-feather="tool"></i> Herramientas compatibles</h2>
   <p class="step-desc">Seleccioná una fresa según el material y la estrategia.</p>
 
   <!-- 7.1) FILTRO POR DIÁMETRO -->

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -147,7 +147,7 @@ if($tool){
 <body class="bg-dark text-white">
 
 <div class="container py-4">
-  <h2 class="step-title"><i class="bi bi-tools"></i> Paso 4 – Confirmar herramienta</h2>
+  <h2 class="step-title"><i data-feather="check-circle"></i> Confirmar herramienta</h2>
   <p class="step-desc">Verificá la fresa sugerida antes de continuar.</p>
 
   <?php if ($error): ?>

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -151,7 +151,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <main class="container py-4" data-debug="step1">
       <div class="d-flex justify-content-between align-items-center mb-4">
         <div>
-          <h2 class="step-title"><i class="bi bi-box-seam"></i> Paso 1 – Explorador de fresas</h2>
+          <h2 class="step-title"><i data-feather="search"></i> Explorador de fresas</h2>
           <p class="step-desc">Elegí la herramienta inicial para el trabajo.</p>
         </div>
         <img src="/wizard-stepper_git/assets/img/logo_nexgen.png"

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -123,7 +123,7 @@ if ($tool) {
 <link rel="stylesheet" href="assets/css/step2_manual.css">
 
 <div class="container py-4">
-  <h2 class="step-title"><i class="bi bi-tools"></i> Paso 2 – Confirmar herramienta</h2>
+  <h2 class="step-title"><i data-feather="check-circle"></i> Confirmar herramienta</h2>
   <p class="step-desc">Revisá los datos de la fresa elegida.</p>
 
   <?php if ($error): ?>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -189,7 +189,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <body>
 <main class="container py-4">
 
-  <h2 class="step-title">Paso 3 – Mecanizado y estrategia</h2>
+  <h2 class="step-title"><i data-feather="settings"></i> Mecanizado y estrategia</h2>
   <p class="step-desc">Definí el tipo de mecanizado y la estrategia a usar.</p>
 
   <?php if ($errors): ?>

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -141,7 +141,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
 <link rel="stylesheet" href="/wizard-stepper_git/assets/css/material.css">
 </head><body>
 <main class="container py-4">
-<h2 class="step-title">Paso 4 – Material y espesor</h2>
+<h2 class="step-title"><i data-feather="layers"></i> Material y espesor</h2>
 <p class="step-desc">Indicá el material a procesar y su espesor.</p>
 
 <?php if($err):?>

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -109,7 +109,7 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
 <link rel="stylesheet" href="/wizard-stepper_git/assets/css/steps/step5.css">
 </head><body>
 <main class="container py-4">
-  <h2 class="step-title">Paso 5 – Configurá tu router</h2>
+  <h2 class="step-title"><i data-feather="cpu"></i> Configurá tu router</h2>
   <p class="step-desc">Ingresá los datos de tu máquina para calcular parámetros.</p>
 
   <?php if ($errors): ?>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -233,7 +233,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 </head>
 <body>
   <div class="container py-4">
-    <h2 class="step-title">Paso 6 – Resultados finales</h2>
+    <h2 class="step-title"><i data-feather="bar-chart-2"></i> Resultados finales</h2>
     <p class="step-desc">Revisá los valores recomendados para el corte.</p>
 <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- standardize `.step-title` appearance across wizard steps
- drop "Paso X" text and add appropriate Feather icons
- load Feather Icons from CDN and call `feather.replace()`

## Testing
- `vendor/bin/phpunit --no-coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540a1fb0cc832cbe6c223759d434fe