### PR TITLE
Move base styles

### DIFF
--- a/assets/css/abstracts/_variables.css
+++ b/assets/css/abstracts/_variables.css
@@ -1,0 +1,27 @@
+:root {
+  --font-family-base: 'Segoe UI', Roboto, sans-serif;
+  --bg-body: #0d1117;
+  --bg-card: #161b22;
+  --bg-header: #0d1117;
+  --border-color: #2c2f33;
+  --text-color: #e0e0e0;
+  --text-color-sec: #a7b1bb;
+  --accent-color: #4fc3f7;
+  --accent-color-light: #7fdcff;
+  --slider-thumb-size: 16px;
+  --spinner-size: 2.5rem;
+  --border-radius-xxl: 1rem;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg-body: #f6f8fa;
+    --bg-card: #fff;
+    --bg-header: #eaf2f8;
+    --border-color: #d0d7de;
+    --text-color: #24292e;
+    --text-color-sec: #57606a;
+    --accent-color: #0077b6;
+    --accent-color-light: #329dd1;
+  }
+}

--- a/assets/css/base/_reset.css
+++ b/assets/css/base/_reset.css
@@ -1,0 +1,11 @@
+/* Reset y normalización básica */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}

--- a/assets/css/base/_typography.css
+++ b/assets/css/base/_typography.css
@@ -1,0 +1,4 @@
+/* Tipografía base para todo el sitio */
+body {
+  font-family: var(--font-family-base, 'Segoe UI', Roboto, sans-serif);
+}

--- a/assets/css/material.css
+++ b/assets/css/material.css
@@ -1,9 +1,12 @@
 /* Common material selection styles */
 
+@import url('abstracts/_variables.css');
+@import url('base/_reset.css');
+@import url('base/_typography.css');
+
 body {
   background-color: #0d1117;
   color: #e0e0e0;
-  font-family: 'Segoe UI', Roboto, sans-serif;
 }
 
 .btn-cat {

--- a/assets/css/step-common.css
+++ b/assets/css/step-common.css
@@ -1,7 +1,10 @@
+@import url('abstracts/_variables.css');
+@import url('base/_reset.css');
+@import url('base/_typography.css');
+
 body {
   background-color: #0d1117;
   color: #e0e0e0;
-  font-family: 'Segoe UI', Roboto, sans-serif;
 }
 
 .btn-type,

--- a/assets/css/step3_scroll.css
+++ b/assets/css/step3_scroll.css
@@ -1,10 +1,13 @@
 /* Infinite scroll styles for step3 */
+@import url('abstracts/_variables.css');
+@import url('base/_reset.css');
+@import url('base/_typography.css');
+
 body {
   --bs-body-bg: #0d1117;
   --bs-body-color: #e0e0e0;
   background-color: var(--bs-body-bg);
   color: var(--bs-body-color);
-  font-family: 'Segoe UI', Roboto, sans-serif;
 }
 
 .fresa-card {

--- a/assets/css/step6-dark.css
+++ b/assets/css/step6-dark.css
@@ -2,7 +2,11 @@
     Hoja oscura para Paso 6 (extraída de la etiqueta <style>)
    ██████████████████████████████████████████████████████████████ */
 
-body{background:#0d1117;color:#e0e0e0;font-family:'Segoe UI',Roboto,sans-serif}
+@import url('abstracts/_variables.css');
+@import url('base/_reset.css');
+@import url('base/_typography.css');
+
+body{background:#0d1117;color:#e0e0e0}
 
 /* ─── Reglas generales ───────────────────────────────────────── */
 .card{background:#161b22;border:1px solid #2c2f33;border-radius:.5rem;margin-bottom:1rem}

--- a/assets/css/step6.css
+++ b/assets/css/step6.css
@@ -5,41 +5,13 @@
  * modo debug con outlines, y estilos refinados para sliders, resultados y debug panel.
  */
 
-/* Variables globales (colores, tamaños) */
-:root {
-  --bg-body: #0d1117;
-  --bg-card: #161b22;
-  --bg-header: #0d1117;
-  --border-color: #2c2f33;
-  --text-color: #e0e0e0;
-  --text-color-sec: #a7b1bb;
-  --accent-color: #4fc3f7;
-  --accent-color-light: #7fdcff;
-  --slider-thumb-size: 16px;
-  --spinner-size: 2.5rem;
-  --border-radius-xxl: 1rem;
-}
-
-/* Tema claro */
-@media (prefers-color-scheme: light) {
-  :root {
-    --bg-body: #f6f8fa;
-    --bg-card: #fff;
-    --bg-header: #eaf2f8;
-    --border-color: #d0d7de;
-    --text-color: #24292e;
-    --text-color-sec: #57606a;
-    --accent-color: #0077b6;
-    --accent-color-light: #329dd1;
-  }
-}
+@import url('abstracts/_variables.css');
+@import url('base/_reset.css');
+@import url('base/_typography.css');
 
 body {
   background: var(--bg-body);
   color: var(--text-color);
-  font-family: 'Segoe UI', Roboto, sans-serif;
-  margin: 0;
-  padding: 0;
 }
 
 /* Tarjetas */

--- a/assets/css/steps/auto/step3.css
+++ b/assets/css/steps/auto/step3.css
@@ -1,11 +1,14 @@
 /* CSS extraído de views/steps/auto/step3.php */
+@import url('../../abstracts/_variables.css');
+@import url('../../base/_reset.css');
+@import url('../../base/_typography.css');
+
 body {
   --bs-body-bg: #0d1117;
   --bs-body-color: #e0e0e0;
 
   background-color: var(--bs-body-bg);
   color: var(--bs-body-color);
-  font-family: 'Segoe UI', Roboto, sans-serif;
 }
 
 h2 {

--- a/assets/css/steps/auto/step4.css
+++ b/assets/css/steps/auto/step4.css
@@ -1,8 +1,11 @@
 /* CSS extraído de views/steps/auto/step4.php */
+@import url('../../abstracts/_variables.css');
+@import url('../../base/_reset.css');
+@import url('../../base/_typography.css');
+
 body {
   background-color: #0d1117;
   color: #e0e0e0;
-  font-family: 'Segoe UI', Roboto, sans-serif;
 }
 
 .wizard-body {

--- a/assets/css/strategy.css
+++ b/assets/css/strategy.css
@@ -1,8 +1,11 @@
 /* Estilos comunes para la selección de estrategia */
+@import url('abstracts/_variables.css');
+@import url('base/_reset.css');
+@import url('base/_typography.css');
+
 body {
   background-color: #0d1117;
   color: #e0e0e0;
-  font-family: 'Segoe UI', Roboto, sans-serif;
 }
 
 .btn-cat {

--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -3,12 +3,13 @@
 /* ────────────────────────────────────────────────────────────────
    GENERAL
    ──────────────────────────────────────────────────────────────── */
+@import url('abstracts/_variables.css');
+@import url('base/_reset.css');
+@import url('base/_typography.css');
+
 body {
   background: #0b1e2d;              /* tono azul-oscuro global   */
   color: #dceefb;                   /* texto casi blanco-celeste */
-  font-family: 'Segoe UI', Roboto, sans-serif; /* tipografía base */
-  margin: 0;                        /* quitamos margen browser   */
-  padding: 0;                       /* …y padding por defecto    */
 }
 
 /* Contenedor del stepper (barra de pasos) */


### PR DESCRIPTION
## Summary
- create `abstracts/_variables.css` with root variables
- create base resets and typography files
- import new base files across stylesheets
- remove duplicate resets and fonts from existing CSS

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541996df14832c94daf6fb7735ef72