### PR TITLE
Simplify CSS references in views

### DIFF
--- a/public/reset.php
+++ b/public/reset.php
@@ -115,7 +115,7 @@ echo <<<'HTML'
   <meta charset="UTF-8">
   <title>Reiniciando Wizard CNC...</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/reset.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body>
   <div class="message-box">

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -8,10 +8,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Wizard CNC</title>
-  <link rel="stylesheet" href="assets/css/main.css">
-  <link rel="stylesheet" href="assets/css/wizard.css">
-  <link rel="stylesheet" href="assets/css/stepper.css">
-  <link rel="stylesheet" href="assets/css/footer-schneider.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body>
 
@@ -59,8 +56,7 @@
   <script>feather.replace();</script>
   <script src="assets/js/stepper.js" defer></script>
   <script src="assets/js/dashboard.js" defer></script>
-<link rel="stylesheet" href="assets/css/wizard.css">
-<link rel="stylesheet" href="assets/css/step6.css"><!-- <---- AGREGALO ACÁ -->
+
 
   <footer class="footer-schneider text-white mt-5">
     <div class="container py-4">

--- a/views/select_mode.php
+++ b/views/select_mode.php
@@ -11,10 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Seleccionar Modo – Wizard CNC</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/main.css">
-  <link rel="stylesheet" href="assets/css/wizard.css">
-  <link rel="stylesheet" href="assets/css/onboarding.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body>
 <main class="wizard-welcome">

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -192,13 +192,7 @@ dbg('children', $children);
   <meta charset="utf-8">
   <title>Paso 1 – Material</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Bootstrap 5 CSS -->
-  <link
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-    rel="stylesheet"
-  >
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/material.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -178,11 +178,7 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
   <meta charset="utf-8">
   <title>Paso 2 – Mecanizado & Estrategia</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Bootstrap 5 -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/strategy.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -157,12 +157,7 @@ try {
   <title>Paso 3 – Herramientas compatibles (Auto)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <!-- Bootstrap 5 (CDN) -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-        rel="stylesheet">
-
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step3_auto.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step3_scroll.php
+++ b/views/steps/auto/step3_scroll.php
@@ -18,8 +18,7 @@ $thickness  = $_SESSION['thickness']  ?? null;
   <title>Herramientas compatibles</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="csrf-token" content="<?= htmlspecialchars($csrf) ?>">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step3.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -139,11 +139,7 @@ if($tool){
   <title>Paso 4 – Confirmar herramienta</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Bootstrap 5 + Icons -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-  <!-- Reutilizamos el mismo CSS del paso manual para un look idéntico -->
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step2.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body class="bg-dark text-white">
 

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -122,17 +122,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <title>Paso 1 – Explorador de fresas (Manual)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <!-- Bootstrap 5 y Bootstrap Icons -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-        rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
-        rel="stylesheet">
-
-  <!-- Estilos propios -->
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step1.css">
-
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_manual.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body>
   <noscript>

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -118,10 +118,7 @@ if ($tool) {
     }
 }
 ?>
-<link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-<link rel="stylesheet" href="assets/css/pages/_step2.css">
+<link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 
 <div class="container py-4">
   <h2 class="step-title"><i data-feather="check-circle"></i> Confirmar herramienta</h2>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -180,12 +180,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <meta charset="utf-8">
   <title>Paso 3 – Tipo de mecanizado & estrategia</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Bootstrap 5 -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <!-- Estilos compartidos -->
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/strategy.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body>
 <main class="container py-4">

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -137,9 +137,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
 <meta charset="utf-8">
 <title>Paso 4 – Material</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/material.css">
+<link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head><body>
 <main class="container py-4">
 <h2 class="step-title"><i data-feather="layers"></i> Material y espesor</h2>

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -104,10 +104,7 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
 <meta charset="utf-8">
 <title>Paso 5 – Configurá tu router</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step5.css">
+<link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head><body>
 <main class="container py-4">
   <h2 class="step-title"><i data-feather="cpu"></i> Configurá tu router</h2>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -227,9 +227,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Datos de corte – Paso 6</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step6.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
   
 </head>
 <body>

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -4,10 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Bienvenido – Wizard CNC</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/main.css">
-  <link rel="stylesheet" href="assets/css/wizard.css">
-  <link rel="stylesheet" href="assets/css/onboarding.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
 </head>
 <body>
   <main class="wizard-welcome">


### PR DESCRIPTION
## Summary
- consolidate stylesheet references across views
- use a single `main.css` include everywhere

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `./vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685452f88150832c8016335ee3ce7318