### PR TITLE
Centralize asset URLs via helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ This project contains a PHP wizard for configuring CNC operations.
    ```
    Then visit [http://localhost:8000](http://localhost:8000).
 
+## Asset URLs
+
+All CSS, JS and image paths should be generated using the helper
+`asset_url()` from `src/Utils/Path.php`. This function prepends the
+current `BASE_URL` to the provided relative path. In the browser the same
+value is exposed as `window.BASE_URL` so that JavaScript modules can build
+their fetch URLs consistently.
+
 ## Debug Endpoints
 
 When running with `?debug=1` in the URL you can access additional debug helpers:

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,4 +1,4 @@
-export const BASE_URL = '/wizard-stepper_git';
+export const BASE_URL = window.BASE_URL || '';
 if (typeof window !== 'undefined') {
   window.BASE_URL = BASE_URL;
 }

--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -2,7 +2,7 @@
     Refuerzo contra respuestas “casi-JSON” (cabecera JSON
     pero texto contaminado con warnings, BOM, etc.).        */
 
-const BASE_URL = window.BASE_URL || '/wizard-stepper_git';
+const BASE_URL = window.BASE_URL || '';
 document.addEventListener('DOMContentLoaded', () => {
   const dash = document.getElementById('wizard-dashboard');
   if (!dash) return;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,6 +1,6 @@
 // File: wizard/assets/js/main.js
 // Controla el botón de inicio y limpia sesión/localStorage
-const BASE_URL = window.BASE_URL || '/wizard-stepper_git';
+const BASE_URL = window.BASE_URL || '';
 document.addEventListener('DOMContentLoaded', () => {
   const btnStart = document.getElementById('btn-start');
   if (!btnStart) return;

--- a/assets/js/step1_manual_browser.js
+++ b/assets/js/step1_manual_browser.js
@@ -6,7 +6,7 @@
  * ▸ Modo DEBUG: loguea TODO en consola + window.dbg()
  * ------------------------------------------------------------ */
 (() => {
-  const BASE_URL = window.BASE_URL || '/wizard-stepper_git';
+  const BASE_URL = window.BASE_URL || '';
   /* -------- utilidades comunes ------------------------------------ */
   const dbg = (...m) => {          // visible en consola + #debug
     console.log('[STEP-1]', ...m);
@@ -99,7 +99,7 @@
       brandWarning.hidden=true;
       cargarTabla();
     }
-    import('/wizard-stepper_git/assets/js/step1_lazy.js')
+    import(`${BASE_URL}/assets/js/step1_lazy.js`)
       .then(m => m.initLazy())
       .catch(console.error);
   }
@@ -128,7 +128,7 @@
                  data-tool_id="${t.tool_id}" data-tbl="${t.tbl}">✓</button></td>
           <td><span class="badge bg-info text-dark">${t.brand}</span></td>
           <td>${t.series_code}</td>
-          <td>${t.details.image?`<img src="/wizard-stepper_git/${t.details.image}" class="thumb">`:''}</td>
+          <td>${t.details.image?`<img src="${BASE_URL}/${t.details.image}" class="thumb">`:''}</td>
           <td>${t.tool_code}</td>
           <td class="text-truncate" style="max-width:200px">${t.name}</td>
           <td>${t.diameter_mm}</td><td>${t.flute_count||'-'}</td><td>${t.tool_type}</td>

--- a/assets/js/step3_lazy.js
+++ b/assets/js/step3_lazy.js
@@ -5,6 +5,7 @@ const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
 const materialId = parseInt(container.dataset.material, 10);
 const strategyId = parseInt(container.dataset.strategy, 10);
 const thickness = parseFloat(container.dataset.thickness || '0');
+const BASE_URL = window.BASE_URL || '';
 
 window.dbg = function (...m) {
   console.log('[STEP3]', ...m);
@@ -57,9 +58,9 @@ function createCard(t) {
   imgCol.className = 'col-md-2 mb-2 mb-md-0';
   const img = document.createElement('img');
   img.className = 'img-fluid tool-thumb';
-  img.src = t.image_url || '/wizard-stepper_git/assets/img/logos/logo_stepper.png';
+  img.src = t.image_url || `${BASE_URL}/assets/img/logos/logo_stepper.png`;
   img.onerror = () => {
-    img.src = '/wizard-stepper_git/assets/img/logos/logo_stepper.png';
+    img.src = `${BASE_URL}/assets/img/logos/logo_stepper.png`;
   };
   imgCol.appendChild(img);
   card.appendChild(imgCol);
@@ -95,7 +96,7 @@ async function fetchPage() {
   if (loading || !hasMore) return;
   loading = true;
   try {
-    const url = `/wizard-stepper_git/ajax/tools_scroll.php?material_id=${materialId}&strategy_id=${strategyId}&page=${page}&per_page=12`;
+    const url = `${BASE_URL}/ajax/tools_scroll.php?material_id=${materialId}&strategy_id=${strategyId}&page=${page}&per_page=12`;
     dbg('fetch', url);
     const res = await fetch(url, { headers: csrf ? { 'X-CSRF-Token': csrf } : {}, cache: 'no-store' });
     if (!res.ok) throw new Error('HTTP ' + res.status);

--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -1,7 +1,7 @@
 /** Ubicación: C:\xampp\htdocs\wizard-stepper_git\assets\js\step6.js */
 /* global Chart */
 (() => {
-  const BASE_URL = window.BASE_URL || '/wizard-stepper_git';
+  const BASE_URL = window.BASE_URL || '';
   // 1. Parámetros inyectados por PHP
   const {
     diameter: D,

--- a/assets/js/stepper.js
+++ b/assets/js/stepper.js
@@ -2,7 +2,7 @@
 (() => {
   'use strict';
 
-  const BASE_URL = window.BASE_URL || '/wizard-stepper_git';
+  const BASE_URL = window.BASE_URL || '';
   const DEBUG = true;
   const LS_KEY = 'wizard_progress';
   const LOAD_ENDPOINT = `${BASE_URL}/public/load-step.php`;
@@ -106,7 +106,7 @@
         if (step === 6) {
           if (!window.step6Loaded) {
             const script = document.createElement('script');
-            script.src = '/wizard-stepper_git/assets/js/step6.js';
+            script.src = `${BASE_URL}/assets/js/step6.js`;
             script.defer = true;
             script.onload = () => { 
               window.step6Loaded = true;

--- a/index.php
+++ b/index.php
@@ -38,6 +38,7 @@ if (!function_exists('dbg')) {
 dbg('🔧 index.php iniciado');
 
 require_once __DIR__ . '/src/Utils/Session.php';
+require_once __DIR__ . '/src/Utils/Path.php';
 
 // -------------------------------------------
 // [B] CABECERAS DE SEGURIDAD HTTP

--- a/public/load-step.php
+++ b/public/load-step.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 require_once __DIR__ . '/../src/Utils/Session.php';
+require_once __DIR__ . '/../src/Utils/Path.php';
 /**
  * File: C:\xampp\htdocs\wizard-stepper_git\load-step.php
  * ---------------------------------------------------------------

--- a/public/reset.php
+++ b/public/reset.php
@@ -36,6 +36,7 @@ if (!function_exists('dbg')) {
 }
 dbg('🔧 reset.php iniciado');
 require_once __DIR__ . '/../src/Utils/Session.php';
+require_once __DIR__ . '/../src/Utils/Path.php';
 
 // -------------------------------------------
 // [2] CABECERAS DE SEGURIDAD Y NO-CACHING
@@ -115,7 +116,7 @@ echo <<<'HTML'
   <meta charset="UTF-8">
   <title>Reiniciando Wizard CNC...</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/reset.css">
+  <link rel="stylesheet" href="<?= asset_url('css/base/reset.css') ?>">
 </head>
 <body>
   <div class="message-box">

--- a/src/Utils/Path.php
+++ b/src/Utils/Path.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Utility helpers for generating URLs to public assets.
+ */
+
+declare(strict_types=1);
+
+// Determine base URL of the application once
+if (!defined('BASE_URL')) {
+    $script = $_SERVER['SCRIPT_NAME'] ?? '';
+    $base   = rtrim(str_replace(basename($script), '', $script), '/');
+    define('BASE_URL', $base ?: '');
+}
+
+if (!function_exists('asset_url')) {
+    /**
+     * Returns an absolute URL for a file under the `assets` directory.
+     */
+    function asset_url(string $path): string
+    {
+        return rtrim(BASE_URL, '/') . '/assets/' . ltrim($path, '/');
+    }
+}

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -8,17 +8,17 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Wizard CNC</title>
-  <link rel="stylesheet" href="assets/css/main.css">
-  <link rel="stylesheet" href="assets/css/wizard.css">
-  <link rel="stylesheet" href="assets/css/stepper.css">
-  <link rel="stylesheet" href="assets/css/footer-schneider.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/wizard.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/stepper.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/footer-schneider.css') ?>">
 </head>
 <body>
 
   <!-- Barra de pasos -->
   <header class="stepper-header d-flex align-items-center">
     <img
-      src="assets/img/logos/logo_stepper.png"
+      src="<?= asset_url('img/logos/logo_stepper.png') ?>"
       alt="Logo Stepper"
       class="logo-stepper">
     <nav class="stepper-bar flex-grow-1">
@@ -57,17 +57,18 @@
   <?php endif; ?>
   <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
   <script>feather.replace();</script>
-  <script src="assets/js/stepper.js" defer></script>
-  <script src="assets/js/dashboard.js" defer></script>
-<link rel="stylesheet" href="assets/css/wizard.css">
-<link rel="stylesheet" href="assets/css/step6.css"><!-- <---- AGREGALO ACÁ -->
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script src="<?= asset_url('js/stepper.js') ?>" defer></script>
+  <script src="<?= asset_url('js/dashboard.js') ?>" defer></script>
+<link rel="stylesheet" href="<?= asset_url('css/wizard.css') ?>">
+<link rel="stylesheet" href="<?= asset_url('css/step6.css') ?>"><!-- <---- AGREGALO ACÁ -->
 
   <footer class="footer-schneider text-white mt-5">
     <div class="container py-4">
       <div class="row align-items-center">
 
         <div class="col-md-6 mb-4 mb-md-0">
-          <img src="assets/img/logos/logo_stepper.png" alt="SchneiderCNC logo" class="footer-logo">
+          <img src="<?= asset_url('img/logos/logo_stepper.png') ?>" alt="SchneiderCNC logo" class="footer-logo">
           <h4 class="fw-bold mb-2">SchneiderCNC</h4>
           <p class="mb-1">Alejandro Martín Schneider</p>
           <p class="mb-1">Córdoba, Argentina</p>

--- a/views/select_mode.php
+++ b/views/select_mode.php
@@ -12,9 +12,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Seleccionar Modo – Wizard CNC</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/main.css">
-  <link rel="stylesheet" href="assets/css/wizard.css">
-  <link rel="stylesheet" href="assets/css/onboarding.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/wizard.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/onboarding.css') ?>">
 </head>
 <body>
 <main class="wizard-welcome">
@@ -42,6 +42,6 @@
   </form>
 </main>
 <script src="https://unpkg.com/lucide@latest"></script>
-<script>lucide.createIcons();</script>
+<script>window.BASE_URL = '<?= BASE_URL ?>'; lucide.createIcons();</script>
 </body>
 </html>

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../src/Utils/Path.php';
 /**
  * File: C:\xampp\htdocs\wizard-stepper_git\views\steps\auto\step1.php
  *
@@ -197,8 +198,8 @@ dbg('children', $children);
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
     rel="stylesheet"
   >
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/material.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/material.css') ?>">
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../src/Utils/Path.php';
 /**
  * File: step2.php
  * ---------------------------------------------------------------
@@ -180,9 +181,9 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Bootstrap 5 -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/strategy.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/strategy.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/step-common.css') ?>">
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -161,8 +161,8 @@ try {
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
         rel="stylesheet">
 
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step3_auto.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/pages/_step3_auto.css') ?>">
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step3_scroll.php
+++ b/views/steps/auto/step3_scroll.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../src/Utils/Path.php';
 require_once __DIR__ . '/../../../includes/wizard_helpers.php';
 
 startSecureSession();
@@ -18,8 +19,8 @@ $thickness  = $_SESSION['thickness']  ?? null;
   <title>Herramientas compatibles</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="csrf-token" content="<?= htmlspecialchars($csrf) ?>">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step3.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/pages/_step3.css') ?>">
 </head>
 <body>
   <main class="container py-4">
@@ -38,6 +39,7 @@ $thickness  = $_SESSION['thickness']  ?? null;
     <div id="scrollSentinel"></div>
     <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>
   </main>
-  <script type="module" src="/wizard-stepper_git/assets/js/step3_lazy.js"></script>
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script type="module" src="<?= asset_url('js/step3_lazy.js') ?>"></script>
 </body>
 </html>

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../src/Utils/Path.php';
 /**
  * File: C:\xampp\htdocs\wizard-stepper_git\views\steps\auto\step4.php
  *
@@ -142,8 +143,8 @@ if($tool){
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <!-- Reutilizamos el mismo CSS del paso manual para un look idéntico -->
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step2.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/pages/_step2.css') ?>">
 </head>
 <body class="bg-dark text-white">
 

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../src/Utils/Path.php';
 
 // ──────────────── 1) Sesión y configuración segura ──────────────────
 if (session_status() !== PHP_SESSION_ACTIVE) {
@@ -125,14 +126,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <!-- Bootstrap 5 y Bootstrap Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
         rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
         rel="stylesheet">
 
   <!-- Estilos propios -->
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step1.css">
+  <link rel="stylesheet" href="<?= asset_url('css/pages/_step1.css') ?>">
 
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_manual.css">
+  <link rel="stylesheet" href="<?= asset_url('css/pages/_manual.css') ?>">
 </head>
 <body>
   <noscript>
@@ -155,7 +156,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           <h2 class="step-title"><i data-feather="search"></i> Explorador de fresas</h2>
           <p class="step-desc">Elegí la herramienta inicial para el trabajo.</p>
         </div>
-        <img src="/wizard-stepper_git/assets/img/logo_nexgen.png"
+        <img src="<?= asset_url('img/logo_nexgen.png') ?>"
              height="46"
              alt="logo"
              onerror="this.remove()">
@@ -234,14 +235,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
   <!-- Script principal del paso (se encarga de rellenar la tabla y habilitar radios) -->
-  <script src="/wizard-stepper_git/assets/js/step1_manual_browser.js"
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script src="<?= asset_url('js/step1_manual_browser.js') ?>"
           onload="window._TOOL_BROWSER_LOADED=true"
           onerror="console.error('❌ step1_manual_browser.js no cargó');">
   </script>
-  <script type="module" src="/wizard-stepper_git/assets/js/step1_lazy.js"></script>
+  <script type="module" src="<?= asset_url('js/step1_lazy.js') ?>"></script>
 
   <script type="module" nonce="<?= $nonce ?>">
-    import { initToolTable } from '/wizard-stepper_git/assets/js/step1_manual_hook.js';
+    import { initToolTable } from `${window.BASE_URL}/assets/js/step1_manual_hook.js`;
     initToolTable();
   </script>
 </body>

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -9,6 +9,7 @@
  */
 declare(strict_types=1);
 require_once __DIR__ . '/../../../includes/db.php';
+require_once __DIR__ . '/../../../src/Utils/Path.php';
 
 /* ---------- util debug ---------------------------------------------------- */
 if (!function_exists('dbg')) {
@@ -120,8 +121,8 @@ if ($tool) {
 ?>
 <link rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-<link rel="stylesheet" href="assets/css/pages/_step2.css">
+<link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+<link rel="stylesheet" href="<?= asset_url('css/pages/_step2.css') ?>">
 
 <div class="container py-4">
   <h2 class="step-title"><i data-feather="check-circle"></i> Confirmar herramienta</h2>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../src/Utils/Path.php';
 /**
  * File: step3.php
  * ------------------------------------------------------------------
@@ -182,10 +183,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Bootstrap 5 -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
   <!-- Estilos compartidos -->
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/strategy.css">
+  <link rel="stylesheet" href="<?= asset_url('css/step-common.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/strategy.css') ?>">
 </head>
 <body>
 <main class="container py-4">

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../src/Utils/Path.php';
 /**
  * File: views/steps/manual/step4.php
  * Paso 4 (Manual) – Selección de madera compatible
@@ -138,8 +139,8 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
 <title>Paso 4 – Material</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/material.css">
+<link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+<link rel="stylesheet" href="<?= asset_url('css/material.css') ?>">
 </head><body>
 <main class="container py-4">
 <h2 class="step-title"><i data-feather="layers"></i> Material y espesor</h2>

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -105,9 +105,9 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
 <title>Paso 5 – Configurá tu router</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step5.css">
+<link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+<link rel="stylesheet" href="<?= asset_url('css/step-common.css') ?>">
+<link rel="stylesheet" href="<?= asset_url('css/pages/_step5.css') ?>">
 </head><body>
 <main class="container py-4">
   <h2 class="step-title"><i data-feather="cpu"></i> Configurá tu router</h2>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -11,6 +11,7 @@ use App\Controller\ExpertResultController;
 // ──────────────────────────────────────────────────────────────
 $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
 require_once __DIR__ . '/../../src/Utils/Session.php';
+require_once __DIR__ . '/../../src/Utils/Path.php';
 
 // [A] CABECERAS DE SEGURIDAD Y NO-CACHING (solo si NO embebido)
 if (!$embedded) {
@@ -137,12 +138,12 @@ $toolType      = htmlspecialchars($toolData['tool_type']   ?? 'N/A', ENT_QUOTES)
 
 // Imagen principal
 $imageURL = !empty($toolData['image'])
-    ? '/wizard-stepper_git/' . ltrim($toolData['image'], '/\\')
+    ? rtrim(BASE_URL, '/') . '/' . ltrim($toolData['image'], '/\\')
     : '';
 
 // Imagen vectorial (usa la columna image_dimensions)
 $vectorURL = !empty($toolData['image_dimensions'])
-    ? '/wizard-stepper_git/' . ltrim($toolData['image_dimensions'], '/\\')
+    ? rtrim(BASE_URL, '/') . '/' . ltrim($toolData['image_dimensions'], '/\\')
     : '';
 
 
@@ -197,9 +198,9 @@ $notesArray = $params['notes'] ?? [];
 
 // Rutas de assets locales vs CDN
 $cssBootstrapRel = file_exists($root . 'assets/css/bootstrap.min.css')
-    ? '/wizard-stepper_git/assets/css/bootstrap.min.css' : '';
+    ? asset_url('css/bootstrap.min.css') : '';
 $bootstrapJsRel  = file_exists($root . 'assets/js/bootstrap.bundle.min.js')
-    ? '/wizard-stepper_git/assets/js/bootstrap.bundle.min.js' : '';
+    ? asset_url('js/bootstrap.bundle.min.js') : '';
 $featherLocal    = $root . 'node_modules/feather-icons/dist/feather.min.js';
 $cdnFeather      = 'https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js';
 $chartJsLocal    = $root . 'node_modules/chart.js/dist/chart.umd.min.js';
@@ -207,7 +208,7 @@ $cdnChartJs      = 'https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js'
 $countUpLocal    = $root . 'node_modules/countup.js/dist/countUp.umd.js';
 $cdnCountUp      = 'https://cdn.jsdelivr.net/npm/countup.js/dist/countUp.umd.min.js';
 $step6JsRel      = file_exists($root . 'assets/js/step6.js')
-    ? '/wizard-stepper_git/assets/js/step6.js' : '';
+    ? asset_url('js/step6.js') : '';
 
 
 
@@ -228,8 +229,8 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Datos de corte – Paso 6</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step6.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/pages/_step6.css') ?>">
   
 </head>
 <body>
@@ -267,9 +268,9 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
           </div>
           <div class="card-body text-center p-4">
             <?php if (!empty($toolData['image'])): ?>
-              <img 
-                src="/wizard-stepper_git/<?= ltrim($toolData['image'], '/\\') ?>" 
-                alt="Imagen principal de la herramienta" 
+              <img
+                src="<?= rtrim(BASE_URL, '/') . '/' . ltrim($toolData['image'], '/\\') ?>"
+                alt="Imagen principal de la herramienta"
                 class="tool-image mx-auto d-block"
               >
             <?php else: ?>
@@ -640,7 +641,8 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js"></script>
-<script src="/wizard-stepper_git/assets/js/step6.js"></script>
+<script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+<script src="<?= $step6JsRel ?: asset_url('js/step6.js') ?>"></script>
 <script>
   window.addEventListener('pageshow', (e) => {
     if (e.persisted) {

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Bienvenido – Wizard CNC</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/main.css">
-  <link rel="stylesheet" href="assets/css/wizard.css">
-  <link rel="stylesheet" href="assets/css/onboarding.css">
+  <link rel="stylesheet" href="<?= asset_url('css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/wizard.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('css/onboarding.css') ?>">
 </head>
 <body>
   <main class="wizard-welcome">
@@ -21,7 +21,8 @@
     </div>
     <button id="btn-start" class="btn btn-primary btn-lg mt-4">Iniciar</button>
   </main>
-  <script src="assets/js/main.js"></script>
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script src="<?= asset_url('js/main.js') ?>"></script>
   <script src="https://unpkg.com/lucide@latest"></script>
   <script>lucide.createIcons();</script>
 </body>


### PR DESCRIPTION
## Summary
- add `asset_url` helper and expose `BASE_URL`
- use helper for asset links across views
- fetch assets via `window.BASE_URL` in JS modules
- document new convention in README

## Testing
- `php -v` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685457563e98832caa07b8c60442c2b0