### PR TITLE
Implement BASE_URL config and unify asset paths

### DIFF
--- a/ajax/ajax_expert_result.php
+++ b/ajax/ajax_expert_result.php
@@ -1,5 +1,6 @@
 <?php
 header('Content-Type: application/json');
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../src/Utils/CNCCalculator.php';
 
 $data = json_decode(file_get_contents('php://input'), true);

--- a/ajax/get_tools.php
+++ b/ajax/get_tools.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../src/Config/AppConfig.php';
+
 // (1) Sesión y seguridad
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_start([

--- a/ajax/paso_minimo_ajax.php
+++ b/ajax/paso_minimo_ajax.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 

--- a/ajax/step6_ajax.php
+++ b/ajax/step6_ajax.php
@@ -1,6 +1,7 @@
 <?php
 // File: C:\xampp\htdocs\wizard-stepper_git\ajax\step6_ajax.php
 declare(strict_types=1);
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 header('Content-Type: application/json; charset=UTF-8');
 
 $input = file_get_contents('php://input');

--- a/ajax/step_minimo_ajax.php
+++ b/ajax/step_minimo_ajax.php
@@ -9,6 +9,7 @@
  */
 
 declare(strict_types=1);
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 
 // Cabeceras JSON
 header('Content-Type: application/json; charset=UTF-8');

--- a/ajax/strategy_ajax.php
+++ b/ajax/strategy_ajax.php
@@ -1,5 +1,6 @@
 <?php
 // strategy_ajax.php
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/db.php';
 
 if (!isset($_GET['ajax']) || $_GET['ajax'] !== '1') {

--- a/ajax/tools_ajax.php
+++ b/ajax/tools_ajax.php
@@ -1,5 +1,6 @@
 <?php
 // tools_ajax.php - Devuelve lista de herramientas filtradas (sin autenticación)
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/db.php';
 require_once __DIR__ . '/../src/Utils/ToolService.php';
 header('Content-Type: application/json; charset=utf-8');

--- a/ajax/tools_scroll.php
+++ b/ajax/tools_scroll.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use PDO;
 
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../src/Utils/Session.php';
 require_once __DIR__ . '/../includes/db.php';
 
@@ -75,7 +76,7 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 foreach ($rows as &$r) {
     $img = $r['image'] ?? '';
-    $r['image_url'] = $img ? '/wizard-stepper_git/' . ltrim((string)$img, '/') : '';
+    $r['image_url'] = $img ? asset($img) : '';
 }
 unset($r);
 

--- a/api/restore_progress.php
+++ b/api/restore_progress.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  */
 
 header('Content-Type: application/json; charset=UTF-8');
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/debug.php';
 
 function dbgLocal(string $msg): void {
@@ -20,7 +21,7 @@ function dbgLocal(string $msg): void {
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_set_cookie_params([
         'lifetime' => 0,
-        'path'     => '/wizard-stepper_git/',
+        'path'     => BASE_URL . '/',
         'secure'   => true,
         'httponly' => true,
         'samesite' => 'Strict',

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,5 +1,2 @@
-export const BASE_URL = '/wizard-stepper_git';
-if (typeof window !== 'undefined') {
-  window.BASE_URL = BASE_URL;
-}
+export const BASE_URL = window.BASE_URL;
 

--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -2,7 +2,7 @@
     Refuerzo contra respuestas “casi-JSON” (cabecera JSON
     pero texto contaminado con warnings, BOM, etc.).        */
 
-const BASE_URL = window.BASE_URL || '/wizard-stepper_git';
+const BASE_URL = window.BASE_URL;
 document.addEventListener('DOMContentLoaded', () => {
   const dash = document.getElementById('wizard-dashboard');
   if (!dash) return;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,6 +1,6 @@
 // File: wizard/assets/js/main.js
 // Controla el botón de inicio y limpia sesión/localStorage
-const BASE_URL = window.BASE_URL || '/wizard-stepper_git';
+const BASE_URL = window.BASE_URL;
 document.addEventListener('DOMContentLoaded', () => {
   const btnStart = document.getElementById('btn-start');
   if (!btnStart) return;

--- a/assets/js/step1_manual_browser.js
+++ b/assets/js/step1_manual_browser.js
@@ -6,7 +6,7 @@
  * ▸ Modo DEBUG: loguea TODO en consola + window.dbg()
  * ------------------------------------------------------------ */
 (() => {
-  const BASE_URL = window.BASE_URL || '/wizard-stepper_git';
+  const BASE_URL = window.BASE_URL;
   /* -------- utilidades comunes ------------------------------------ */
   const dbg = (...m) => {          // visible en consola + #debug
     console.log('[STEP-1]', ...m);
@@ -99,7 +99,7 @@
       brandWarning.hidden=true;
       cargarTabla();
     }
-    import('/wizard-stepper_git/assets/js/step1_lazy.js')
+    import(`${BASE_URL}/assets/js/step1_lazy.js`)
       .then(m => m.initLazy())
       .catch(console.error);
   }
@@ -128,7 +128,7 @@
                  data-tool_id="${t.tool_id}" data-tbl="${t.tbl}">✓</button></td>
           <td><span class="badge bg-info text-dark">${t.brand}</span></td>
           <td>${t.series_code}</td>
-          <td>${t.details.image?`<img src="/wizard-stepper_git/${t.details.image}" class="thumb">`:''}</td>
+          <td>${t.details.image?`<img src="${BASE_URL}/${t.details.image}" class="thumb">`:''}</td>
           <td>${t.tool_code}</td>
           <td class="text-truncate" style="max-width:200px">${t.name}</td>
           <td>${t.diameter_mm}</td><td>${t.flute_count||'-'}</td><td>${t.tool_type}</td>

--- a/assets/js/step3_lazy.js
+++ b/assets/js/step3_lazy.js
@@ -57,9 +57,9 @@ function createCard(t) {
   imgCol.className = 'col-md-2 mb-2 mb-md-0';
   const img = document.createElement('img');
   img.className = 'img-fluid tool-thumb';
-  img.src = t.image_url || '/wizard-stepper_git/assets/img/logos/logo_stepper.png';
+  img.src = t.image_url || `${window.BASE_URL}/assets/img/logos/logo_stepper.png`;
   img.onerror = () => {
-    img.src = '/wizard-stepper_git/assets/img/logos/logo_stepper.png';
+    img.src = `${window.BASE_URL}/assets/img/logos/logo_stepper.png`;
   };
   imgCol.appendChild(img);
   card.appendChild(imgCol);
@@ -95,7 +95,7 @@ async function fetchPage() {
   if (loading || !hasMore) return;
   loading = true;
   try {
-    const url = `/wizard-stepper_git/ajax/tools_scroll.php?material_id=${materialId}&strategy_id=${strategyId}&page=${page}&per_page=12`;
+    const url = `${window.BASE_URL}/ajax/tools_scroll.php?material_id=${materialId}&strategy_id=${strategyId}&page=${page}&per_page=12`;
     dbg('fetch', url);
     const res = await fetch(url, { headers: csrf ? { 'X-CSRF-Token': csrf } : {}, cache: 'no-store' });
     if (!res.ok) throw new Error('HTTP ' + res.status);

--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -1,7 +1,7 @@
 /** Ubicación: C:\xampp\htdocs\wizard-stepper_git\assets\js\step6.js */
 /* global Chart */
 (() => {
-  const BASE_URL = window.BASE_URL || '/wizard-stepper_git';
+  const BASE_URL = window.BASE_URL;
   // 1. Parámetros inyectados por PHP
   const {
     diameter: D,

--- a/assets/js/stepper.js
+++ b/assets/js/stepper.js
@@ -2,7 +2,7 @@
 (() => {
   'use strict';
 
-  const BASE_URL = window.BASE_URL || '/wizard-stepper_git';
+  const BASE_URL = window.BASE_URL;
   const DEBUG = true;
   const LS_KEY = 'wizard_progress';
   const LOAD_ENDPOINT = `${BASE_URL}/public/load-step.php`;
@@ -106,7 +106,7 @@
         if (step === 6) {
           if (!window.step6Loaded) {
             const script = document.createElement('script');
-            script.src = '/wizard-stepper_git/assets/js/step6.js';
+            script.src = `${BASE_URL}/assets/js/step6.js`;
             script.defer = true;
             script.onload = () => { 
               window.step6Loaded = true;

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/src/Config/AppConfig.php';
 /**
  * File: index.php
  * Router principal del Wizard CNC

--- a/public/export.php
+++ b/public/export.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/security.php';
 
 session_start();

--- a/public/export_json.php
+++ b/public/export_json.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/security.php';
 
 session_start();

--- a/public/handle-step.php
+++ b/public/handle-step.php
@@ -1,5 +1,6 @@
 <?php
 /** File: handle-step.php */
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 session_start();
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../src/StepperFlow.php';

--- a/public/load-step.php
+++ b/public/load-step.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../src/Utils/Session.php';
 /**
  * File: C:\xampp\htdocs\wizard-stepper_git\load-step.php

--- a/public/reset.php
+++ b/public/reset.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 /**
  * File: reset.php
  * ---------------------------------------------------------------
@@ -115,7 +116,7 @@ echo <<<'HTML'
   <meta charset="UTF-8">
   <title>Reiniciando Wizard CNC...</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/base/reset.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/base/reset.css') ?>">
 </head>
 <body>
   <div class="message-box">

--- a/public/session-api.php
+++ b/public/session-api.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/security.php';
 
 session_start();

--- a/public/tools_facets.php
+++ b/public/tools_facets.php
@@ -10,6 +10,7 @@
  */
 
 declare(strict_types=1);
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 header('Content-Type: application/json; charset=utf-8');
 
 // DEBUG MODE (activá en local dev)

--- a/public/tools_search.php
+++ b/public/tools_search.php
@@ -1,5 +1,6 @@
 <?php
 // tools_search.php
+require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/db.php';
 
 header('Content-Type: application/json; charset=utf-8');

--- a/src/Config/AppConfig.php
+++ b/src/Config/AppConfig.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+if (!defined('BASE_URL')) {
+    $base = getenv('BASE_URL') ?: '/wizard-stepper_git';
+    define('BASE_URL', rtrim($base, '/'));
+}
+
+if (!function_exists('asset')) {
+    function asset(string $path): string
+    {
+        return BASE_URL . '/' . ltrim($path, '/');
+    }
+}

--- a/src/Controller/AutoToolRecommenderController.php
+++ b/src/Controller/AutoToolRecommenderController.php
@@ -79,11 +79,11 @@ class AutoToolRecommenderController
     {
         self::initSession();
         if (empty($_SESSION['material_id']) || !is_numeric($_SESSION['material_id'])) {
-            header('Location: /wizard-stepper_git/public/load-step.php?step=2');
+            header('Location: ' . asset('public/load-step.php?step=2'));
             exit;
         }
         if (empty($_SESSION['strategy_id']) || !is_numeric($_SESSION['strategy_id'])) {
-            header('Location: /wizard-stepper_git/public/load-step.php?step=3');
+            header('Location: ' . asset('public/load-step.php?step=3'));
             exit;
         }
     }
@@ -102,7 +102,7 @@ class AutoToolRecommenderController
         $progress = (int)($_SESSION['wizard_progress'] ?? 0);
 
         if ($state !== 'wizard' || $progress < $minProgress) {
-            header('Location: /wizard-stepper_git/index.php');
+            header('Location: ' . asset('index.php'));
             exit;
         }
     }

--- a/src/Utils/ToolService.php
+++ b/src/Utils/ToolService.php
@@ -43,7 +43,7 @@ class ToolService
             return '';
         }
 
-        $path = '/wizard-stepper_git/' . ltrim((string)$img, "\\/");
+        $path = asset((string)$img);
         $_SESSION['tool_images'][$table][$toolId] = $path;
         return $path;
     }

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="assets/css/wizard.css">
   <link rel="stylesheet" href="assets/css/stepper.css">
   <link rel="stylesheet" href="assets/css/footer-schneider.css">
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body>
 

--- a/views/select_mode.php
+++ b/views/select_mode.php
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="assets/css/main.css">
   <link rel="stylesheet" href="assets/css/wizard.css">
   <link rel="stylesheet" href="assets/css/onboarding.css">
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body>
 <main class="wizard-welcome">

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -44,7 +44,7 @@ if ($DEBUG && function_exists('dbg')) {
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_set_cookie_params([
         'lifetime' => 0,
-        'path'     => '/wizard-stepper_git/',    // Fuerza la ruta base
+        'path'     => BASE_URL . '/',    // Fuerza la ruta base
         'domain'   => '',                    // Ajusta si usas dominio
         'secure'   => true,                  // Solo HTTPS
         'httponly' => true,                  // Inaccesible a JavaScript
@@ -59,8 +59,8 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 // -------------------------------------------
 // Si no venimos del index.php que fijó wizard_state='wizard', volvemos a index.php.
 if (empty($_SESSION['wizard_state']) || $_SESSION['wizard_state'] !== 'wizard') {
-    dbg('❌ wizard_state no válido → redirigiendo a /wizard-stepper_git/index.php');
-    header('Location: /wizard-stepper_git/index.php');
+    dbg('❌ wizard_state no válido → redirigiendo a ' . BASE_URL . '/index.php');
+    header('Location: ' . asset('index.php'));
     exit;
 }
 
@@ -137,8 +137,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         dbg("✅ Paso 1 completado: material={$mat}, thickness={$thk}");
         session_write_close();
 
-        // Redirigir a Paso 2 (ruta absoluta dentro de /wizard-stepper_git/)
-        header('Location: /wizard-stepper_git/views/steps/auto/step2.php');
+        // Redirigir a Paso 2 (ruta absoluta dentro de la app)
+        header('Location: ' . asset('views/steps/auto/step2.php'));
         exit;
     }
 }
@@ -197,8 +197,8 @@ dbg('children', $children);
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
     rel="stylesheet"
   >
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/material.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/material.css') ?>">
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -42,7 +42,7 @@ if ($DEBUG && function_exists('dbg')) {
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_set_cookie_params([
         'lifetime' => 0,
-        'path'     => '/wizard-stepper_git/',
+        'path'     => BASE_URL . '/',
         'domain'   => '',
         'secure'   => true,
         'httponly' => true,
@@ -180,9 +180,9 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Bootstrap 5 -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/strategy.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/strategy.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/step-common.css') ?>">
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -77,7 +77,7 @@ try {
 } catch (\RuntimeException $e) {
     dbg("❌ [step3] checkStep lanzó excepción: " . $e->getMessage());
     // Si falla la precondición, forzamos redirección a inicio del wizard
-    header('Location: /wizard-stepper_git/index.php');
+    header('Location: ' . asset('index.php'));
     exit;
 }
 
@@ -85,7 +85,7 @@ try {
 $currentProgress = (int)($_SESSION['wizard_progress'] ?? 0);
 if ($currentProgress < 2) {
     dbg("⚠ [step3] Progreso insuficiente ({$currentProgress}) → redirigir a paso 2");
-    header('Location: /wizard-stepper_git/public/load-step.php?step=2');
+    header('Location: ' . asset('public/load-step.php?step=2'));
     exit;
 }
 
@@ -130,7 +130,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $_SESSION['wizard_progress'] = 3;
     session_regenerate_id(true);
     dbg("✅ [step3][POST] Herramienta guardada en sesión → tool_id={$toolIdRaw} tool_table={$toolTblClean}");
-    header('Location: /wizard-stepper_git/public/load-step.php?step=4');
+    header('Location: ' . asset('public/load-step.php?step=4'));
     exit;
 }
 
@@ -143,7 +143,7 @@ try {
 } catch (\RuntimeException $e) {
     dbg("❌ [step3][GET] getSessionData lanzó excepción: " . $e->getMessage());
     // Si por algún motivo falta material/estrategia, redirigimos a paso 2
-    header('Location: /wizard-stepper_git/public/load-step.php?step=2');
+    header('Location: ' . asset('public/load-step.php?step=2'));
     exit;
 }
 
@@ -161,8 +161,9 @@ try {
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
         rel="stylesheet">
 
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step3_auto.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/pages/_step3_auto.css') ?>">
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body>
   <main class="container py-4">
@@ -242,7 +243,7 @@ try {
      */
     async function fetchTools() {
       try {
-        const url = `/wizard-stepper_git/ajax/get_tools.php?material_id=${encodeURIComponent(materialId)}&strategy_id=${encodeURIComponent(strategyId)}`;
+        const url = `${window.BASE_URL}/ajax/get_tools.php?material_id=${encodeURIComponent(materialId)}&strategy_id=${encodeURIComponent(strategyId)}`;
         dbg('⬇ [step3.js] Fetch →', url);
         const resp = await fetch(url, { cache: 'no-store' });
         if (!resp.ok) {
@@ -317,7 +318,7 @@ try {
         // Celdas internas (imagen / detalles / botón)
         const imgCol = document.createElement('div');
         imgCol.className = 'col-md-2 mb-2 mb-md-0';
-        const baseUrl = '/wizard-stepper_git/';
+        const baseUrl = window.BASE_URL + '/';
         const img = document.createElement('img');
         img.className = 'img-fluid tool-thumb';
         if (tool.image) {

--- a/views/steps/auto/step3_scroll.php
+++ b/views/steps/auto/step3_scroll.php
@@ -18,8 +18,9 @@ $thickness  = $_SESSION['thickness']  ?? null;
   <title>Herramientas compatibles</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="csrf-token" content="<?= htmlspecialchars($csrf) ?>">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step3.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/pages/_step3.css') ?>">
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body>
   <main class="container py-4">
@@ -38,6 +39,6 @@ $thickness  = $_SESSION['thickness']  ?? null;
     <div id="scrollSentinel"></div>
     <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>
   </main>
-  <script type="module" src="/wizard-stepper_git/assets/js/step3_lazy.js"></script>
+  <script type="module" src="<?= asset('assets/js/step3_lazy.js') ?>"></script>
 </body>
 </html>

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -33,7 +33,7 @@ if ($DEBUG && function_exists('dbg')) dbg('🔧 step4.php iniciado');
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_set_cookie_params([
         'lifetime' => 0,
-        'path'     => '/wizard-stepper_git/',
+        'path'     => BASE_URL . '/',
         'secure'   => true,
         'httponly' => true,
         'samesite' => 'Strict'
@@ -46,10 +46,10 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 // [D] Validar flujo (wizard_progress ≥ 3)
 // ──────────────────────────────────────────────────────────────
 if (empty($_SESSION['wizard_state']) || $_SESSION['wizard_state'] !== 'wizard') {
-    header('Location: /wizard-stepper_git/index.php'); exit;
+    header('Location: ' . asset('index.php')); exit;
 }
 if (($_SESSION['wizard_progress'] ?? 0) < 3) {
-    header('Location: /wizard-stepper_git/views/steps/auto/step3.php'); exit;
+    header('Location: ' . asset('views/steps/auto/step3.php')); exit;
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -125,7 +125,7 @@ else $error='Faltan parámetros para confirmar la herramienta.';
 // ──────────────────────────────────────────────────────────────
 if($tool){
     $tool['length_total_mm']??=$tool['full_length_mm']??0;
-    if(!empty($tool['image'])) $tool['image_url']='/wizard-stepper_git/'.ltrim($tool['image'],'/');
+    if(!empty($tool['image'])) $tool['image_url'] = asset($tool['image']);
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -142,8 +142,9 @@ if($tool){
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <!-- Reutilizamos el mismo CSS del paso manual para un look idéntico -->
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step2.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/pages/_step2.css') ?>">
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body class="bg-dark text-white">
 

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -125,14 +125,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <!-- Bootstrap 5 y Bootstrap Icons -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
         rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
         rel="stylesheet">
 
   <!-- Estilos propios -->
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step1.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/pages/_step1.css') ?>">
 
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_manual.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/pages/_manual.css') ?>">
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body>
   <noscript>
@@ -155,7 +156,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           <h2 class="step-title"><i data-feather="search"></i> Explorador de fresas</h2>
           <p class="step-desc">Elegí la herramienta inicial para el trabajo.</p>
         </div>
-        <img src="/wizard-stepper_git/assets/img/logo_nexgen.png"
+        <img src="<?= asset('assets/img/logo_nexgen.png') ?>"
              height="46"
              alt="logo"
              onerror="this.remove()">
@@ -234,14 +235,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
   <!-- Script principal del paso (se encarga de rellenar la tabla y habilitar radios) -->
-  <script src="/wizard-stepper_git/assets/js/step1_manual_browser.js"
+  <script src="<?= asset('assets/js/step1_manual_browser.js') ?>"
           onload="window._TOOL_BROWSER_LOADED=true"
           onerror="console.error('❌ step1_manual_browser.js no cargó');">
   </script>
-  <script type="module" src="/wizard-stepper_git/assets/js/step1_lazy.js"></script>
+  <script type="module" src="<?= asset('assets/js/step1_lazy.js') ?>"></script>
 
   <script type="module" nonce="<?= $nonce ?>">
-    import { initToolTable } from '/wizard-stepper_git/assets/js/step1_manual_hook.js';
+      import { initToolTable } from '<?= asset('assets/js/step1_manual_hook.js') ?>';
     initToolTable();
   </script>
 </body>

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -114,14 +114,15 @@ if ($tool) {
     if (!empty($_SESSION['tool_image_url'])) {
         $tool['image_url'] = rtrim((string)$_SESSION['tool_image_url'], '/');
     } elseif (!empty($tool['image'])) {
-        $tool['image_url'] = '/wizard-stepper_git/' . ltrim((string)$tool['image'], '/');
+        $tool['image_url'] = asset((string)$tool['image']);
     }
 }
 ?>
 <link rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
+<link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
 <link rel="stylesheet" href="assets/css/pages/_step2.css">
+<script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 
 <div class="container py-4">
   <h2 class="step-title"><i data-feather="check-circle"></i> Confirmar herramienta</h2>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -42,7 +42,7 @@ if ($DEBUG && function_exists('dbg')) {
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_set_cookie_params([
         'lifetime' => 0,
-        'path'     => '/wizard-stepper_git/',
+        'path'     => BASE_URL . '/',
         'domain'   => '',
         'secure'   => true,
         'httponly' => true,
@@ -182,10 +182,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Bootstrap 5 -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <!-- Estilos compartidos -->
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/strategy.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/step-common.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/strategy.css') ?>">
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body>
 <main class="container py-4">

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -31,7 +31,7 @@ if ($DEBUG && function_exists('dbg')) dbg('🔧 step4.php iniciado');
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_set_cookie_params([
         'lifetime'=>0,
-        'path'    =>'/wizard-stepper_git/',
+        'path'    => BASE_URL . '/',
         'secure'  =>true,
         'httponly'=>true,
         'samesite'=>'Strict'
@@ -44,10 +44,10 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 // [D] Control de flujo
 //
 if (empty($_SESSION['wizard_state']) || $_SESSION['wizard_state']!=='wizard') {
-    header('Location:/wizard-stepper_git/index.php'); exit;
+    header('Location:' . asset('index.php')); exit;
 }
 if ((int)($_SESSION['wizard_progress']??0) < 3) {
-    header('Location:/wizard-stepper_git/views/steps/auto/step'.(int)$_SESSION['wizard_progress'].'.php'); exit;
+    header('Location:' . asset('views/steps/auto/step' . (int)$_SESSION['wizard_progress'] . '.php')); exit;
 }
 
 //
@@ -77,7 +77,7 @@ require_once __DIR__.'/../../../includes/db.php';
 require_once __DIR__.'/../../../includes/debug.php';
 
 if (empty($_SESSION['tool_id']) || empty($_SESSION['tool_table'])) {
-    header('Location:/wizard-stepper_git/views/steps/auto/step2.php'); exit;
+    header('Location:' . asset('views/steps/auto/step2.php')); exit;
 }
 $toolId   = (int)$_SESSION['tool_id'];
 $toolTbl  = preg_replace('/[^a-z0-9_]/i','',$_SESSION['tool_table']);
@@ -129,7 +129,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
         $_SESSION['material_id']=$mat;
         $_SESSION['thickness'] =(float)$thk;
         $_SESSION['wizard_progress']=4;
-        header('Location:/wizard-stepper_git/views/steps/manual/step5.php'); exit;
+        header('Location:' . asset('views/steps/manual/step5.php')); exit;
     }
 }
 ?>
@@ -138,8 +138,9 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
 <title>Paso 4 – Material</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/material.css">
+<link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+<link rel="stylesheet" href="<?= asset('assets/css/material.css') ?>">
+<script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head><body>
 <main class="container py-4">
 <h2 class="step-title"><i data-feather="layers"></i> Material y espesor</h2>

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -105,9 +105,10 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
 <title>Paso 5 – Configurá tu router</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/step-common.css">
-<link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step5.css">
+<link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+<link rel="stylesheet" href="<?= asset('assets/css/step-common.css') ?>">
+<link rel="stylesheet" href="<?= asset('assets/css/pages/_step5.css') ?>">
+<script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head><body>
 <main class="container py-4">
   <h2 class="step-title"><i data-feather="cpu"></i> Configurá tu router</h2>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -137,12 +137,12 @@ $toolType      = htmlspecialchars($toolData['tool_type']   ?? 'N/A', ENT_QUOTES)
 
 // Imagen principal
 $imageURL = !empty($toolData['image'])
-    ? '/wizard-stepper_git/' . ltrim($toolData['image'], '/\\')
+    ? asset($toolData['image'])
     : '';
 
 // Imagen vectorial (usa la columna image_dimensions)
 $vectorURL = !empty($toolData['image_dimensions'])
-    ? '/wizard-stepper_git/' . ltrim($toolData['image_dimensions'], '/\\')
+    ? asset($toolData['image_dimensions'])
     : '';
 
 
@@ -197,9 +197,9 @@ $notesArray = $params['notes'] ?? [];
 
 // Rutas de assets locales vs CDN
 $cssBootstrapRel = file_exists($root . 'assets/css/bootstrap.min.css')
-    ? '/wizard-stepper_git/assets/css/bootstrap.min.css' : '';
+    ? asset('assets/css/bootstrap.min.css') : '';
 $bootstrapJsRel  = file_exists($root . 'assets/js/bootstrap.bundle.min.js')
-    ? '/wizard-stepper_git/assets/js/bootstrap.bundle.min.js' : '';
+    ? asset('assets/js/bootstrap.bundle.min.js') : '';
 $featherLocal    = $root . 'node_modules/feather-icons/dist/feather.min.js';
 $cdnFeather      = 'https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js';
 $chartJsLocal    = $root . 'node_modules/chart.js/dist/chart.umd.min.js';
@@ -207,7 +207,7 @@ $cdnChartJs      = 'https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js'
 $countUpLocal    = $root . 'node_modules/countup.js/dist/countUp.umd.js';
 $cdnCountUp      = 'https://cdn.jsdelivr.net/npm/countup.js/dist/countUp.umd.min.js';
 $step6JsRel      = file_exists($root . 'assets/js/step6.js')
-    ? '/wizard-stepper_git/assets/js/step6.js' : '';
+    ? asset('assets/js/step6.js') : '';
 
 
 
@@ -228,9 +228,10 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Datos de corte – Paso 6</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/main.css">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step6.css">
-  
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/pages/_step6.css') ?>">
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+
 </head>
 <body>
   <div class="container py-4">
@@ -267,9 +268,9 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
           </div>
           <div class="card-body text-center p-4">
             <?php if (!empty($toolData['image'])): ?>
-              <img 
-                src="/wizard-stepper_git/<?= ltrim($toolData['image'], '/\\') ?>" 
-                alt="Imagen principal de la herramienta" 
+              <img
+                src="<?= htmlspecialchars($imageURL, ENT_QUOTES) ?>"
+                alt="Imagen principal de la herramienta"
                 class="tool-image mx-auto d-block"
               >
             <?php else: ?>
@@ -640,7 +641,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js"></script>
-<script src="/wizard-stepper_git/assets/js/step6.js"></script>
+<script src="<?= asset('assets/js/step6.js') ?>"></script>
 <script>
   window.addEventListener('pageshow', (e) => {
     if (e.persisted) {

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="assets/css/main.css">
   <link rel="stylesheet" href="assets/css/wizard.css">
   <link rel="stylesheet" href="assets/css/onboarding.css">
+  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body>
   <main class="wizard-welcome">


### PR DESCRIPTION
## Summary
- create `AppConfig` with `BASE_URL` constant and `asset()` helper
- load config across entry points
- expose `BASE_URL` to pages and JS
- update JS modules to rely on `window.BASE_URL`
- replace hardcoded paths with the helper

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545beecdc4832c9b99833ef781d4c5