### PR TITLE
Refactor asset links & session cookie paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ This project contains a PHP wizard for configuring CNC operations.
    ```
 4. Adjust database credentials in `includes/db.php` if needed.
 5. Start the application using PHP's built‑in server:
-   ```bash
-   php -S localhost:8000
-   ```
-   Then visit [http://localhost:8000](http://localhost:8000).
+ ```bash
+  php -S localhost:8000
+  ```
+  Then visit [http://localhost:8000](http://localhost:8000).
+
+6. When adding links to CSS, JavaScript or image files in your views, generate the
+   path with the `asset()` helper so URLs work from any base path.
 
 ## Debug Endpoints
 

--- a/public/reset.php
+++ b/public/reset.php
@@ -51,7 +51,7 @@ header('Pragma: no-cache');
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_set_cookie_params([
         'lifetime' => 0,
-        'path'     => '/',
+        'path'     => BASE_URL . '/',
         'domain'   => '',        // Ajustar si se requiere dominio específico
         'secure'   => true,
         'httponly' => true,

--- a/src/Utils/Session.php
+++ b/src/Utils/Session.php
@@ -14,7 +14,7 @@ if (!function_exists('startSecureSession')) {
         if (session_status() !== PHP_SESSION_ACTIVE) {
             session_set_cookie_params([
                 'lifetime' => 0,
-                'path'     => '/',
+                'path'     => BASE_URL . '/',
                 'domain'   => '',
                 'secure'   => true,
                 'httponly' => true,

--- a/views/layout_wizard.php
+++ b/views/layout_wizard.php
@@ -8,10 +8,10 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Wizard CNC</title>
-  <link rel="stylesheet" href="assets/css/main.css">
-  <link rel="stylesheet" href="assets/css/wizard.css">
-  <link rel="stylesheet" href="assets/css/stepper.css">
-  <link rel="stylesheet" href="assets/css/footer-schneider.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/stepper.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/footer-schneider.css') ?>">
   <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body>
@@ -19,7 +19,7 @@
   <!-- Barra de pasos -->
   <header class="stepper-header d-flex align-items-center">
     <img
-      src="assets/img/logos/logo_stepper.png"
+      src="<?= asset('assets/img/logos/logo_stepper.png') ?>"
       alt="Logo Stepper"
       class="logo-stepper">
     <nav class="stepper-bar flex-grow-1">
@@ -58,17 +58,17 @@
   <?php endif; ?>
   <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
   <script>feather.replace();</script>
-  <script src="assets/js/stepper.js" defer></script>
-  <script src="assets/js/dashboard.js" defer></script>
-<link rel="stylesheet" href="assets/css/wizard.css">
-<link rel="stylesheet" href="assets/css/step6.css"><!-- <---- AGREGALO ACÁ -->
+  <script src="<?= asset('assets/js/stepper.js') ?>" defer></script>
+  <script src="<?= asset('assets/js/dashboard.js') ?>" defer></script>
+<link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
+<link rel="stylesheet" href="<?= asset('assets/css/step6.css') ?>"><!-- <---- AGREGALO ACÁ -->
 
   <footer class="footer-schneider text-white mt-5">
     <div class="container py-4">
       <div class="row align-items-center">
 
         <div class="col-md-6 mb-4 mb-md-0">
-          <img src="assets/img/logos/logo_stepper.png" alt="SchneiderCNC logo" class="footer-logo">
+          <img src="<?= asset('assets/img/logos/logo_stepper.png') ?>" alt="SchneiderCNC logo" class="footer-logo">
           <h4 class="fw-bold mb-2">SchneiderCNC</h4>
           <p class="mb-1">Alejandro Martín Schneider</p>
           <p class="mb-1">Córdoba, Argentina</p>

--- a/views/select_mode.php
+++ b/views/select_mode.php
@@ -12,9 +12,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Seleccionar Modo – Wizard CNC</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/main.css">
-  <link rel="stylesheet" href="assets/css/wizard.css">
-  <link rel="stylesheet" href="assets/css/onboarding.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/onboarding.css') ?>">
   <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body>

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -121,7 +121,7 @@ if ($tool) {
 <link rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
 <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
-<link rel="stylesheet" href="assets/css/pages/_step2.css">
+<link rel="stylesheet" href="<?= asset('assets/css/pages/_step2.css') ?>">
 <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 
 <div class="container py-4">

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -27,7 +27,7 @@ require_once __DIR__ . '/../../includes/wizard_helpers.php';
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_set_cookie_params([
         'lifetime' => 0,
-        'path'     => '/',
+        'path'     => BASE_URL . '/',
         'secure'   => true,
         'httponly' => true,
         'samesite' => 'Strict'

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Bienvenido – Wizard CNC</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/main.css">
-  <link rel="stylesheet" href="assets/css/wizard.css">
-  <link rel="stylesheet" href="assets/css/onboarding.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/onboarding.css') ?>">
   <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
 </head>
 <body>
@@ -22,7 +22,7 @@
     </div>
     <button id="btn-start" class="btn btn-primary btn-lg mt-4">Iniciar</button>
   </main>
-  <script src="assets/js/main.js"></script>
+  <script src="<?= asset('assets/js/main.js') ?>"></script>
   <script src="https://unpkg.com/lucide@latest"></script>
   <script>lucide.createIcons();</script>
 </body>


### PR DESCRIPTION
## Summary
- use asset() helper across views for CSS/JS/image references
- tie session cookie paths to BASE_URL
- document asset() helper usage in README

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6854602cd67c832c862c475a667329fe