### PR TITLE
Add units to CNC wizard forms

### DIFF
--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -255,16 +255,19 @@ dbg('children', $children);
 
     <!-- 4) Espesor (se muestra tras elegir Material) -->
     <div id="thickGroup" class="mb-3" style="display:none">
-      <label for="thick" class="form-label">Espesor (mm)</label>
-      <input
-        type="number"
-        id="thick"
-        name="thickness"
-        class="form-control"
-        step="0.1"
-        min="0.1"
-        required
-      >
+      <label for="thick" class="form-label">Espesor</label>
+      <div class="input-group">
+        <input
+          type="number"
+          id="thick"
+          name="thickness"
+          class="form-control"
+          step="0.1"
+          min="0.1"
+          required
+        >
+        <span class="input-group-text">mm</span>
+      </div>
     </div>
 
     <!-- 5) Botón “Siguiente” -->

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -180,8 +180,11 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
 
   <!-- 4) Espesor -->
   <div id="thickGroup" class="mb-3" style="display:none">
-    <label for="thick" class="form-label">Espesor (mm)</label>
-    <input type="number" id="thick" name="thickness" class="form-control" step="0.1" min="0.1" required>
+    <label for="thick" class="form-label">Espesor</label>
+    <div class="input-group">
+      <input type="number" id="thick" name="thickness" class="form-control" step="0.1" min="0.1" required>
+      <span class="input-group-text">mm</span>
+    </div>
   </div>
 
   <!-- 5) Botón “Siguiente” -->

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -146,17 +146,20 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
       <div class="row g-3">
         <?php
           $fields=[
-            ['rpm_min','RPM mínima',1],
-            ['rpm_max','RPM máxima',1],
-            ['feed_max','Avance máx (mm/min)',0.1],
-            ['hp','Potencia (HP)',0.1],
+            ['rpm_min','RPM mínima',1,'rpm'],
+            ['rpm_max','RPM máxima',1,'rpm'],
+            ['feed_max','Avance máx (mm/min)',0.1,'mm/min'],
+            ['hp','Potencia (HP)',0.1,'HP'],
           ];
-          foreach($fields as [$id,$label,$step]): ?>
+          foreach($fields as [$id,$label,$step,$unit]): ?>
         <div class="col-md-3">
           <label for="<?=$id?>" class="form-label"><?=$label?></label>
-          <input type="number" class="form-control" id="<?=$id?>" name="<?=$id?>"
-                 step="<?=$step?>" min="1" value="<?=htmlspecialchars((string)$prev[$id])?>" required>
-          <div class="invalid-feedback"></div>
+          <div class="input-group has-validation">
+            <input type="number" class="form-control" id="<?=$id?>" name="<?=$id?>"
+                   step="<?=$step?>" min="1" value="<?=htmlspecialchars((string)$prev[$id])?>" required>
+            <span class="input-group-text"><?=$unit?></span>
+            <div class="invalid-feedback"></div>
+          </div>
         </div>
         <?php endforeach; ?>
       </div>
@@ -210,7 +213,8 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
     let ok = true;
     const v  = k => parseFloat(inputs[k].value) || 0;
     const fb = (inp,msg) => {
-      inp.nextElementSibling.textContent = msg;
+      const feedback = inp.parentElement.querySelector('.invalid-feedback');
+      feedback.textContent = msg;
       inp.classList.toggle('is-invalid', !!msg);
       if (msg) ok = false;
     };


### PR DESCRIPTION
## Summary
- add input group addons for unit display in router configuration step
- adjust JS validation for new layout
- show mm addon for thickness input in automatic flow
- show mm addon for thickness input in manual flow

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f85957e0832ca60eae4c8b1100c2