### PR TITLE
Handle expired CSRF on step 6

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -163,6 +163,12 @@
         body: JSON.stringify(payload),
         cache: 'no-store'
       });
+      if (res.status === 403) {
+        return showError('Sesión expirada. Recargá la página.');
+      }
+      if (res.status === 404) {
+        return showError('Ruta paso 6 no encontrada (404). Verificá BASE_URL.');
+      }
       if (!res.ok) {
         return showError(`AJAX error ${res.status}`);
       }


### PR DESCRIPTION
## Summary
- show a helpful message when CSRF token is invalid in `step6.js`
- show a clearer message when the Step 6 endpoint returns 404

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685602227bf8832ca6e7d809de57058b