### PR TITLE
Handle 404 errors in step6

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ DB_HOST=localhost
 DB_NAME=cnc_calculador
 DB_USER=root
 DB_PASS=
+BASE_URL=/wizard-stepper_git

--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ This project contains a PHP wizard for configuring CNC operations.
   ```
   Then visit [http://localhost:8000](http://localhost:8000).
 
-6. When adding links to CSS, JavaScript or image files in your views, generate the
+6. If you host the project under a different path, set the `BASE_URL`
+   environment variable accordingly. For example, to serve it from the
+   root directory:
+   ```bash
+   BASE_URL="" php -S localhost:8000
+   ```
+   This prevents 404 errors when AJAX requests look for `/ajax/*.php`.
+
+7. When adding links to CSS, JavaScript or image files in your views, generate the
    path with the `asset()` helper so URLs work from any base path.
 
 ## Debug Endpoints

--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -163,6 +163,12 @@
         body: JSON.stringify(payload),
         cache: 'no-store'
       });
+      if (res.status === 403) {
+        return showError('Sesión expirada. Recargá la página.');
+      }
+      if (res.status === 404) {
+        return showError('Ruta paso 6 no encontrada. Revisá BASE_URL.');
+      }
       if (!res.ok) {
         return showError(`AJAX error ${res.status}`);
       }


### PR DESCRIPTION
## Summary
- document BASE_URL usage for non-root installs
- show a hint when step6 AJAX returns 404
- include BASE_URL in `.env.example`

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: 24 errors)*
- `composer run-script lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685602227bf8832ca6e7d809de57058b