### PR TITLE
Fix CSRF check in step6 ajax

### DIFF
--- a/ajax/step6_ajax_legacy_minimal.php
+++ b/ajax/step6_ajax_legacy_minimal.php
@@ -20,7 +20,7 @@ session_start();
 
 // 0. CSRF: validar token enviado en header X-CSRF-Token
 $token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
-if (!hash_equals($_SESSION['csrf_token'], $token)) {
+if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
     http_response_code(403);
     exit('CSRF fail');
 }


### PR DESCRIPTION
## Summary
- properly validate CSRF token in `step6_ajax_legacy_minimal.php`

## Testing
- `npm run lint:css` *(fails: 24 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68560653ff64832cace014a93ac66ea1