### PR TITLE
Fix legacy endpoint alias for Step 6

### DIFF
--- a/ajax/step_minimo_ajax.php
+++ b/ajax/step_minimo_ajax.php
@@ -1,0 +1,3 @@
+<?php
+// Simple wrapper for backwards compatibility
+require __DIR__ . '/paso_minimo_ajax.php';


### PR DESCRIPTION
## Summary
- create `ajax/step_minimo_ajax.php` as a wrapper to `paso_minimo_ajax.php`

## Testing
- `npm test` *(fails: Missing script)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685609afcf78832c9665a4d89d4465e7