### PR TITLE
Fix module scripts and scroll loader params

### DIFF
--- a/assets/js/step1_manual_lazy_loader.js
+++ b/assets/js/step1_manual_lazy_loader.js
@@ -7,6 +7,8 @@ export let hasMore = true;
 export const sentinel = document.getElementById('sentinel');
 export const tbody = document.querySelector('#toolTbl tbody');
 const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
+const materialId = document.querySelector('meta[name="material-id"]')?.content || '';
+const strategyId = document.querySelector('meta[name="strategy-id"]')?.content || '';
 
 console.log('Sentinel:', sentinel);
 
@@ -28,7 +30,12 @@ export async function loadPage() {
   if (loading || !hasMore || !tbody) return;
   loading = true;
   try {
-    const res = await fetch(`${BASE_URL}/ajax/tools_scroll.php?page=${page}`, {
+    const params = new URLSearchParams({
+      page,
+      material_id: materialId,
+      strategy_id: strategyId,
+    });
+    const res = await fetch(`${BASE_URL}/ajax/tools_scroll.php?${params}`, {
       cache: 'no-store',
       headers: csrf ? { 'X-CSRF-Token': csrf } : {},
     });

--- a/assets/js/wizard_stepper.js
+++ b/assets/js/wizard_stepper.js
@@ -54,6 +54,8 @@
         if (!document.querySelector(`head script[src="${tag.src}"]`)) {
           const s = document.createElement('script');
           s.src = tag.src;
+          if (tag.type) s.type = tag.type;     // preservar type="module" si existe
+          if (tag.nonce) s.nonce = tag.nonce;  // mantener CSP
           s.defer = true;
           s.onload = () => log(`[stepper.js] Cargado: ${tag.src}`);
           s.onerror = () => console.error(`[stepper.js] ⚠️ Falló carga: ${tag.src}`);
@@ -63,6 +65,8 @@
         // Scripts inline (vital para cada paso)
         try {
           const inlineScript = document.createElement('script');
+          if (tag.type) inlineScript.type = tag.type;
+          if (tag.nonce) inlineScript.nonce = tag.nonce;
           inlineScript.textContent = tag.textContent;
           document.body.appendChild(inlineScript).remove();
           log('[stepper.js] Ejecutado inline script');

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -119,6 +119,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
   <meta charset="utf-8">
   <meta name="csrf-token" content="<?= htmlspecialchars($csrfToken) ?>">
+  <?php $matId = $_SESSION['material_id'] ?? ''; ?>
+  <?php $stratId = $_SESSION['strategy_id'] ?? ''; ?>
+  <meta name="material-id" content="<?= htmlspecialchars((string)$matId) ?>">
+  <meta name="strategy-id" content="<?= htmlspecialchars((string)$stratId) ?>">
   <title>Paso 1 – Explorador de fresas (Manual)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
## Summary
- preserve `type` and `nonce` when executing step scripts so ES modules work after AJAX load
- expose `material_id` and `strategy_id` on step1 view
- include those params when requesting `tools_scroll.php`

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `composer run-script lint` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6856179a6db8832c9d36407b88093287