### PR TITLE
Fix lazy loader request without IDs

### DIFF
--- a/assets/js/step1_manual_lazy_loader.js
+++ b/assets/js/step1_manual_lazy_loader.js
@@ -7,8 +7,14 @@ export let hasMore = true;
 export const sentinel = document.getElementById('sentinel');
 export const tbody = document.querySelector('#toolTbl tbody');
 const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
-const materialId = document.querySelector('meta[name="material-id"]')?.content || '';
-const strategyId = document.querySelector('meta[name="strategy-id"]')?.content || '';
+const materialId = parseInt(
+  document.querySelector('meta[name="material-id"]')?.content || '',
+  10,
+);
+const strategyId = parseInt(
+  document.querySelector('meta[name="strategy-id"]')?.content || '',
+  10,
+);
 
 console.log('Sentinel:', sentinel);
 
@@ -28,6 +34,11 @@ const observer = new IntersectionObserver(
 
 export async function loadPage() {
   if (loading || !hasMore || !tbody) return;
+  if (!Number.isInteger(materialId) || !Number.isInteger(strategyId)) {
+    console.warn('Missing material_id or strategy_id; aborting lazy load');
+    hasMore = false;
+    return;
+  }
   loading = true;
   try {
     const params = new URLSearchParams({


### PR DESCRIPTION
## Summary
- avoid sending invalid `material_id` and `strategy_id` in the manual lazy loader
- parse the IDs as integers and abort fetching when missing

## Testing
- `npx eslint assets/js/step1_manual_lazy_loader.js` *(fails: Unexpected token 'export')*
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685619bef01c832c95f65ed1e7e93f79