### PR TITLE
Fix chart init duplicate issue

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -45,7 +45,10 @@
   if (+sVc.value > vcMaxAllowed) sVc.value = vcMaxAllowed.toFixed(1);
 
   // 4. Radar Chart init
-  const ctx = document.getElementById('radarChart').getContext('2d');
+  const canvas = document.getElementById('radarChart');
+  const existing = Chart.getChart(canvas);
+  if (existing) existing.destroy();
+  const ctx = canvas.getContext('2d');
   const radar = new Chart(ctx, {
     type: 'radar',
     data: {


### PR DESCRIPTION
## Summary
- destroy existing radar chart before creating a new one

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561b189054832c9b33d54607afd669