### PR TITLE
Fix Chart.js legend.fullSize safety

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -69,6 +69,12 @@ window.radarChartInstance = window.radarChartInstance || null;
   });
   const radar = window.radarChartInstance;
 
+  // Asegura que la estructura plugins.legend exista antes de modificarla
+  if (!radar.options) radar.options = {};
+  if (!radar.options.plugins) radar.options.plugins = {};
+  radar.options.plugins.legend = radar.options.plugins.legend || {};
+  radar.options.plugins.legend.fullSize = true;
+
   // 5. Mostrar/ocultar errores
   function showError(msg) {
     err.style.display = 'block';


### PR DESCRIPTION
## Summary
- ensure plugins.legend object exists
- set `legend.fullSize` safely to avoid runtime errors

## Testing
- `npx eslint assets/js/step6.js` *(fails: ESLint config issue)*

------
https://chatgpt.com/codex/tasks/task_e_68561d59d9f8832c9a5e9a4b37a6e016