### PR TITLE
Normalize project paths using BASE_URL

### DIFF
--- a/ajax/ajax_expert_result.php
+++ b/ajax/ajax_expert_result.php
@@ -1,5 +1,6 @@
 <?php
 header('Content-Type: application/json');
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../src/Utils/CNCCalculator.php';
 

--- a/ajax/get_tools.php
+++ b/ajax/get_tools.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 
 // (1) Sesión y seguridad

--- a/ajax/step6_ajax_calculate.php
+++ b/ajax/step6_ajax_calculate.php
@@ -1,6 +1,7 @@
 <?php
 // File: C:\xampp\htdocs\wizard-stepper_git\ajax\step6_ajax_calculate.php
 declare(strict_types=1);
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 header('Content-Type: application/json; charset=UTF-8');
 

--- a/ajax/step6_ajax_legacy_minimal.php
+++ b/ajax/step6_ajax_legacy_minimal.php
@@ -9,6 +9,7 @@
  */
 
 declare(strict_types=1);
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 
 // Cabeceras JSON

--- a/ajax/strategy_ajax.php
+++ b/ajax/strategy_ajax.php
@@ -1,5 +1,6 @@
 <?php
 // strategy_ajax.php
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/db.php';
 

--- a/ajax/tools_ajax.php
+++ b/ajax/tools_ajax.php
@@ -1,5 +1,6 @@
 <?php
 // tools_ajax.php - Devuelve lista de herramientas filtradas (sin autenticación)
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/db.php';
 require_once __DIR__ . '/../src/Utils/ToolService.php';

--- a/ajax/tools_scroll.php
+++ b/ajax/tools_scroll.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use PDO;
 
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../src/Utils/Session.php';
 require_once __DIR__ . '/../includes/db.php';

--- a/api/restore_progress.php
+++ b/api/restore_progress.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  */
 
 header('Content-Type: application/json; charset=UTF-8');
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/debug.php';
 

--- a/includes/init.php
+++ b/includes/init.php
@@ -1,0 +1,7 @@
+<?php
+if (!defined('BASE_URL')) {
+    $scheme = isset($_SERVER['HTTPS']) ? 'https' : 'http';
+    $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    $path   = dirname($_SERVER['SCRIPT_NAME']);
+    define('BASE_URL', rtrim("{$scheme}://{$host}{$path}", '/\\') . '/');
+}

--- a/public/export.php
+++ b/public/export.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/security.php';
 

--- a/public/export_json.php
+++ b/public/export_json.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/security.php';
 

--- a/public/handle-step.php
+++ b/public/handle-step.php
@@ -1,5 +1,6 @@
 <?php
 /** File: handle-step.php */
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 session_start();
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/public/load-step.php
+++ b/public/load-step.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../src/Utils/Session.php';
 /**

--- a/public/reset.php
+++ b/public/reset.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 /**
  * File: reset.php

--- a/public/session-api.php
+++ b/public/session-api.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/security.php';
 

--- a/public/tools_facets.php
+++ b/public/tools_facets.php
@@ -10,6 +10,7 @@
  */
 
 declare(strict_types=1);
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 header('Content-Type: application/json; charset=utf-8');
 

--- a/public/tools_search.php
+++ b/public/tools_search.php
@@ -1,5 +1,6 @@
 <?php
 // tools_search.php
+require_once __DIR__ . '/../includes/init.php';
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/db.php';
 

--- a/src/Config/AppConfig.php
+++ b/src/Config/AppConfig.php
@@ -9,6 +9,6 @@ if (!defined('BASE_URL')) {
 if (!function_exists('asset')) {
     function asset(string $path): string
     {
-        return BASE_URL . '/' . ltrim($path, '/');
+        return rtrim(BASE_URL, '/') . '/' . ltrim($path, '/');
     }
 }

--- a/views/select_mode.php
+++ b/views/select_mode.php
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/onboarding.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 </head>
 <body>
 <main class="wizard-welcome">

--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -163,7 +163,7 @@ try {
 
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/pages/step3_auto_tool_recommendation.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step3_auto_lazy_browser.php
+++ b/views/steps/auto/step3_auto_lazy_browser.php
@@ -20,7 +20,7 @@ $thickness  = $_SESSION['thickness']  ?? null;
   <meta name="csrf-token" content="<?= htmlspecialchars($csrf) ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/pages/_step3.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -144,7 +144,7 @@ if($tool){
   <!-- Reutilizamos el mismo CSS del paso manual para un look idéntico -->
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/pages/_step2.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 </head>
 <body class="bg-dark text-white">
 

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -137,7 +137,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <link rel="stylesheet" href="<?= asset('assets/css/pages/_step1.css') ?>">
 
   <link rel="stylesheet" href="<?= asset('assets/css/pages/_manual.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 </head>
 <body>
   <noscript>

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -122,7 +122,7 @@ if ($tool) {
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
 <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/pages/_step2.css') ?>">
-<script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+<script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 
 <div class="container py-4">
   <h2 class="step-title"><i data-feather="check-circle"></i> Confirmar herramienta</h2>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -186,7 +186,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <!-- Estilos compartidos -->
   <link rel="stylesheet" href="<?= asset('assets/css/step-common.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/strategy.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 </head>
 <body>
 <main class="container py-4">

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -140,7 +140,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/material.css') ?>">
-<script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+<script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 </head><body>
 <main class="container py-4">
 <h2 class="step-title"><i data-feather="layers"></i> Material y espesor</h2>

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -108,7 +108,7 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
 <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/step-common.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/pages/_step5.css') ?>">
-<script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+<script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 </head><body>
 <main class="container py-4">
   <h2 class="step-title"><i data-feather="cpu"></i> Configurá tu router</h2>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -141,12 +141,12 @@ $toolType      = htmlspecialchars($toolData['tool_type']   ?? 'N/A', ENT_QUOTES)
 
 // Imagen principal
 $imageURL = !empty($toolData['image'])
-    ? '/wizard-stepper_git/' . ltrim($toolData['image'], '/\\')
+    ? BASE_URL . ltrim($toolData['image'], '/\\')
     : '';
 
 // Imagen vectorial (usa la columna image_dimensions)
 $vectorURL = !empty($toolData['image_dimensions'])
-    ? '/wizard-stepper_git/' . ltrim($toolData['image_dimensions'], '/\\')
+    ? BASE_URL . ltrim($toolData['image_dimensions'], '/\\')
     : '';
 
 
@@ -201,9 +201,9 @@ $notesArray = $params['notes'] ?? [];
 
 // Rutas de assets locales vs CDN
 $cssBootstrapRel = file_exists($root . 'assets/css/bootstrap.min.css')
-    ? '/wizard-stepper_git/assets/css/bootstrap.min.css' : '';
+    ? BASE_URL . 'assets/css/bootstrap.min.css' : '';
 $bootstrapJsRel  = file_exists($root . 'assets/js/bootstrap.bundle.min.js')
-    ? '/wizard-stepper_git/assets/js/bootstrap.bundle.min.js' : '';
+    ? BASE_URL . 'assets/js/bootstrap.bundle.min.js' : '';
 $featherLocal    = $root . 'node_modules/feather-icons/dist/feather.min.js';
 $cdnFeather      = 'https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js';
 $chartJsLocal    = $root . 'node_modules/chart.js/dist/chart.umd.min.js';
@@ -211,7 +211,7 @@ $cdnChartJs      = 'https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js'
 $countUpLocal    = $root . 'node_modules/countup.js/dist/countUp.umd.js';
 $cdnCountUp      = 'https://cdn.jsdelivr.net/npm/countup.js/dist/countUp.umd.min.js';
 $step6JsRel      = file_exists($root . 'assets/js/step6.js')
-    ? '/wizard-stepper_git/assets/js/step6.js' : '';
+    ? BASE_URL . 'assets/js/step6.js' : '';
 
 
 
@@ -232,7 +232,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Cutting Data Épico – Paso 6</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step6.css">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/pages/_step6.css">
   
 </head>
 <body>
@@ -269,7 +269,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
           <div class="card-body text-center p-4">
             <?php if (!empty($toolData['image'])): ?>
               <img 
-                src="/wizard-stepper_git/<?= ltrim($toolData['image'], '/\\') ?>" 
+                src="<?= BASE_URL . ltrim($toolData['image'], '/\\') ?>"
                 alt="Imagen principal de la herramienta" 
                 class="tool-image mx-auto d-block"
               >
@@ -629,7 +629,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js"></script>
-<script src="/wizard-stepper_git/assets/js/step6.js"></script>
+<script src="<?= BASE_URL ?>assets/js/step6.js"></script>
 <script>
   window.addEventListener('pageshow', (e) => {
     if (e.persisted) {

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/onboarding.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 </head>
 <body>
   <main class="wizard-welcome">

--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/stepper.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/footer-schneider.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>const BASE_URL = "<?= BASE_URL ?>"; window.BASE_URL = BASE_URL;</script>
 </head>
 <body>
 

--- a/wizard.php
+++ b/wizard.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require_once __DIR__ . '/includes/init.php';
 require_once __DIR__ . '/src/Config/AppConfig.php';
 /**
  * File: wizard.php


### PR DESCRIPTION
## Summary
- create `includes/init.php` defining a global `BASE_URL` constant
- reference `includes/init.php` from executable PHP files
- use `BASE_URL` in main layout and pages for JS
- adjust asset helper for trailing slash safety
- convert hard-coded paths in step 6

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561eeb81ec832c8c803128bd43663a