### PR TITLE
Add BASE_URL init and update welcome stylesheet path

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -1,0 +1,2 @@
+<?php
+define('BASE_URL', rtrim((isset($_SERVER['HTTPS']) ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['SCRIPT_NAME']), '/\\') . '/');

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../includes/init.php'; ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -5,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Bienvenido – Wizard CNC</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
+  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
   <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/onboarding.css') ?>">
   <script>window.BASE_URL = '<?= BASE_URL ?>';</script>


### PR DESCRIPTION
## Summary
- introduce `includes/init.php` that defines `BASE_URL`
- require the init file inside `views/welcome.php`
- load main stylesheet using the new `BASE_URL` constant

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685623b764e8832ca0f003251e396716