### PR TITLE
Fix wizard reset clears localStorage immediately

### DIFF
--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -35,7 +35,7 @@
 
   <!-- Botón reset -->
   <div style="text-align:right; padding:.5rem 1rem;">
-    <a href="public/reset.php" class="btn btn-outline-light">
+    <a href="public/reset.php" class="btn btn-outline-light" onclick="localStorage.clear()">
       <i data-feather="refresh-ccw" class="me-1"></i>
       Volver al inicio
     </a>


### PR DESCRIPTION
## Summary
- clear localStorage as soon as the user clicks "Volver al inicio"

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `composer run-script lint` *(fails: Script "lint" is not defined)*
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6856285497e8832c906396a991cca3d3