### PR TITLE
Fix asset paths with helper

### DIFF
--- a/public/reset.php
+++ b/public/reset.php
@@ -109,7 +109,7 @@ dbg('🔄 Sesión regenerada y destruida nuevamente para mayor seguridad');
 // -------------------------------------------
 // [8] HTML + JS PARA BORRAR localStorage Y REDIRIGIR
 // -------------------------------------------
-echo <<<'HTML'
+?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -132,10 +132,10 @@ echo <<<'HTML'
     }
     // Redirigir a wizard.php tras un breve retardo (200ms)
     setTimeout(function() {
-      window.location.replace('../wizard.php');
+      window.location.replace('<?= asset('wizard.php') ?>');
     }, 200);
   </script>
 </body>
 </html>
-HTML;
+<?php
 exit;

--- a/views/select_mode.php
+++ b/views/select_mode.php
@@ -15,7 +15,10 @@
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/onboarding.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
 <main class="wizard-welcome">

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -199,6 +199,10 @@ dbg('children', $children);
   >
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/material.css') ?>">
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -183,6 +183,10 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/strategy.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/step-common.css') ?>">
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -163,7 +163,10 @@ try {
 
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/pages/step3_auto_tool_recommendation.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step3_auto_lazy_browser.php
+++ b/views/steps/auto/step3_auto_lazy_browser.php
@@ -20,7 +20,10 @@ $thickness  = $_SESSION['thickness']  ?? null;
   <meta name="csrf-token" content="<?= htmlspecialchars($csrf) ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/pages/_step3.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
   <main class="container py-4">

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -144,7 +144,10 @@ if($tool){
   <!-- Reutilizamos el mismo CSS del paso manual para un look idéntico -->
   <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/pages/_step2.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body class="bg-dark text-white">
 

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -137,7 +137,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <link rel="stylesheet" href="<?= asset('assets/css/pages/_step1.css') ?>">
 
   <link rel="stylesheet" href="<?= asset('assets/css/pages/_manual.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
   <noscript>

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -122,7 +122,10 @@ if ($tool) {
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
 <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/pages/_step2.css') ?>">
-<script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+<script>
+  window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+  window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+</script>
 
 <div class="container py-4">
   <h2 class="step-title"><i data-feather="check-circle"></i> Confirmar herramienta</h2>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -186,7 +186,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <!-- Estilos compartidos -->
   <link rel="stylesheet" href="<?= asset('assets/css/step-common.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/strategy.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
 <main class="container py-4">

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -140,7 +140,10 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/material.css') ?>">
-<script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+<script>
+  window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+  window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+</script>
 </head><body>
 <main class="container py-4">
 <h2 class="step-title"><i data-feather="layers"></i> Material y espesor</h2>

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -108,7 +108,10 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
 <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/step-common.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/pages/_step5.css') ?>">
-<script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+<script>
+  window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+  window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+</script>
 </head><body>
 <main class="container py-4">
   <h2 class="step-title"><i data-feather="cpu"></i> Configurá tu router</h2>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -141,12 +141,12 @@ $toolType      = htmlspecialchars($toolData['tool_type']   ?? 'N/A', ENT_QUOTES)
 
 // Imagen principal
 $imageURL = !empty($toolData['image'])
-    ? '/wizard-stepper_git/' . ltrim($toolData['image'], '/\\')
+    ? asset((string)$toolData['image'])
     : '';
 
 // Imagen vectorial (usa la columna image_dimensions)
 $vectorURL = !empty($toolData['image_dimensions'])
-    ? '/wizard-stepper_git/' . ltrim($toolData['image_dimensions'], '/\\')
+    ? asset((string)$toolData['image_dimensions'])
     : '';
 
 
@@ -201,9 +201,9 @@ $notesArray = $params['notes'] ?? [];
 
 // Rutas de assets locales vs CDN
 $cssBootstrapRel = file_exists($root . 'assets/css/bootstrap.min.css')
-    ? '/wizard-stepper_git/assets/css/bootstrap.min.css' : '';
+    ? asset('assets/css/bootstrap.min.css') : '';
 $bootstrapJsRel  = file_exists($root . 'assets/js/bootstrap.bundle.min.js')
-    ? '/wizard-stepper_git/assets/js/bootstrap.bundle.min.js' : '';
+    ? asset('assets/js/bootstrap.bundle.min.js') : '';
 $featherLocal    = $root . 'node_modules/feather-icons/dist/feather.min.js';
 $cdnFeather      = 'https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js';
 $chartJsLocal    = $root . 'node_modules/chart.js/dist/chart.umd.min.js';
@@ -211,7 +211,7 @@ $cdnChartJs      = 'https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js'
 $countUpLocal    = $root . 'node_modules/countup.js/dist/countUp.umd.js';
 $cdnCountUp      = 'https://cdn.jsdelivr.net/npm/countup.js/dist/countUp.umd.min.js';
 $step6JsRel      = file_exists($root . 'assets/js/step6.js')
-    ? '/wizard-stepper_git/assets/js/step6.js' : '';
+    ? asset('assets/js/step6.js') : '';
 
 
 
@@ -232,7 +232,11 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Cutting Data Épico – Paso 6</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="/wizard-stepper_git/assets/css/pages/_step6.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/pages/_step6.css') ?>">
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
   
 </head>
 <body>
@@ -268,9 +272,9 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
           </div>
           <div class="card-body text-center p-4">
             <?php if (!empty($toolData['image'])): ?>
-              <img 
-                src="/wizard-stepper_git/<?= ltrim($toolData['image'], '/\\') ?>" 
-                alt="Imagen principal de la herramienta" 
+              <img
+                src="<?= htmlspecialchars($imageURL, ENT_QUOTES) ?>"
+                alt="Imagen principal de la herramienta"
                 class="tool-image mx-auto d-block"
               >
             <?php else: ?>
@@ -629,7 +633,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js"></script>
-<script src="/wizard-stepper_git/assets/js/step6.js"></script>
+<script src="<?= asset('assets/js/step6.js') ?>"></script>
 <script>
   window.addEventListener('pageshow', (e) => {
     if (e.persisted) {

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -6,10 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Bienvenido – Wizard CNC</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/onboarding.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
   <main class="wizard-welcome">

--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -12,7 +12,10 @@
   <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/stepper.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/footer-schneider.css') ?>">
-  <script>window.BASE_URL = '<?= BASE_URL ?>';</script>
+  <script>
+    window.BASE_URL = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- use `asset()` helper instead of hard coded paths
- expose `BASE_URL` and `BASE_HOST` in all views
- load assets dynamically in step6
- allow PHP in reset view

## Testing
- `vendor/bin/phpunit -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856346ec744832c93ab6ec14cc192cf