### PR TITLE
Allow loading tools before selecting strategy

### DIFF
--- a/ajax/tools_scroll.php
+++ b/ajax/tools_scroll.php
@@ -37,7 +37,7 @@ if ($materialId === false || $materialId === null) {
 if ($strategyId === false || $strategyId === null) {
     $strategyId = $_SESSION['strategy_id'] ?? null;
 }
-if ($materialId === null || $strategyId === null) {
+if ($materialId === null) {
     http_response_code(400);
     echo json_encode(['error' => 'missing_params']);
     exit;
@@ -63,7 +63,9 @@ foreach ($defs as $d) {
              . " '{$d['brand']}' AS brand, '{$d['table']}' AS source_table,"
              . " tm.rating, t.image"
              . " FROM {$d['table']} t"
-             . " JOIN toolstrategy ts ON ts.tool_table='{$d['table']}' AND ts.tool_id=t.tool_id AND ts.strategy_id=:sid"
+             . ($strategyId !== null
+                ? " JOIN toolstrategy ts ON ts.tool_table='{$d['table']}' AND ts.tool_id=t.tool_id AND ts.strategy_id=:sid"
+                : '')
              . " JOIN {$d['mat']} tm ON tm.tool_id=t.tool_id AND tm.material_id=:mid"
              . " JOIN series s ON s.id=t.series_id";
 }
@@ -72,7 +74,9 @@ $sql = implode(' UNION ALL ', $parts)
      . ' ORDER BY rating DESC LIMIT :limit OFFSET :offset';
 
 $stmt = $pdo->prepare($sql);
-$stmt->bindValue(':sid', $strategyId, PDO::PARAM_INT);
+if ($strategyId !== null) {
+    $stmt->bindValue(':sid', $strategyId, PDO::PARAM_INT);
+}
 $stmt->bindValue(':mid', $materialId, PDO::PARAM_INT);
 $stmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
 $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);

--- a/assets/js/step1_manual_lazy_loader.js
+++ b/assets/js/step1_manual_lazy_loader.js
@@ -11,10 +11,8 @@ const materialId = parseInt(
   document.querySelector('meta[name="material-id"]')?.content || '',
   10,
 );
-const strategyId = parseInt(
-  document.querySelector('meta[name="strategy-id"]')?.content || '',
-  10,
-);
+const strategyMeta = document.querySelector('meta[name="strategy-id"]');
+const strategyId = strategyMeta ? parseInt(strategyMeta.content, 10) : null;
 
 console.log('Sentinel:', sentinel);
 
@@ -34,8 +32,8 @@ const observer = new IntersectionObserver(
 
 export async function loadPage() {
   if (loading || !hasMore || !tbody) return;
-  if (!Number.isInteger(materialId) || !Number.isInteger(strategyId)) {
-    console.warn('Missing material_id or strategy_id; aborting lazy load');
+  if (!Number.isInteger(materialId)) {
+    console.warn('Missing material_id; aborting lazy load');
     hasMore = false;
     return;
   }
@@ -44,8 +42,10 @@ export async function loadPage() {
     const params = new URLSearchParams({
       page,
       material_id: materialId,
-      strategy_id: strategyId,
     });
+    if (Number.isInteger(strategyId)) {
+      params.append('strategy_id', strategyId);
+    }
     const res = await fetch(`${BASE_URL}/ajax/tools_scroll.php?${params}`, {
       cache: 'no-store',
       headers: csrf ? { 'X-CSRF-Token': csrf } : {},


### PR DESCRIPTION
## Summary
- remove strategy requirement from lazy loader
- update `tools_scroll.php` to make `strategy_id` optional

## Testing
- `npm run lint` *(fails: Missing script)*
- `composer run-script lint` *(fails: composer not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68563b5435bc832c87fd5091cd4ca313