### PR TITLE
Setup PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "industrial/wizard-cnc",
     "type": "project",
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "monolog/monolog": "^3.9",
         "vlucas/phpdotenv": "^5.6",
         "nikic/fast-route": "^1.3"
@@ -14,7 +14,11 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^10",
         "phpstan/phpstan": "^2.1"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
     }
 }
+

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" colors="true">
-  <testsuites>
-    <testsuite name="WizardTests">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
+    <testsuites>
+        <testsuite name="Application">
+            <directory suffix="Test.php">tests/</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>
+

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
+{
+    public function testTrue(): void
+    {
+        $this->assertTrue(true);
+    }
+}
+


### PR DESCRIPTION
## Summary
- update PHPUnit to latest major version for PHP 8.1
- configure composer script for running tests
- provide basic phpunit.xml
- add a minimal example test

## Testing
- `composer install --no-interaction --no-progress` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f0257aa0832cb83e43ab90bf4898