### PR TITLE
Fix HTML structure for step6 and cleanup layout

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -464,9 +464,8 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
           </div>
         </div>
       </div>
-
-
-
+    </div>
+  </div>
 
 
   <!-- ESPECIFICACIONES TÉCNICAS & IMAGEN VECTORIAL -->
@@ -620,6 +619,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
           </div>
         </div>
       </div>
+</div>
 </div>
  
 

--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -63,8 +63,6 @@
   <script>feather.replace();</script>
   <script src="<?= asset('assets/js/wizard_stepper.js') ?>" defer></script>
   <script src="<?= asset('assets/js/dashboard.js') ?>" defer></script>
-<link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
-  <link rel="stylesheet" href="<?= asset('assets/css/pages/_step6.css') ?>"><!-- <---- AGREGALO ACÁ -->
 
   <footer class="footer-schneider text-white mt-5">
     <div class="container py-4">


### PR DESCRIPTION
## Summary
- ensure closing containers in step 6 view
- remove duplicate CSS includes from wizard layout

## Testing
- `npm run lint` *(fails: Missing script)*
- `composer run-script lint` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6856f59fdd7c832ca4c21c6ee1b491e8