### PR TITLE
Fix step6 stylesheet loading

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -239,10 +239,12 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
     window.BASE_URL = <?= json_encode(BASE_URL) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
   </script>
-  
+
 </head>
 <body>
   <div class="container py-4">
+<?php else: ?>
+  <link rel="stylesheet" href="<?= asset('assets/css/pages/_step6.css') ?>">
 <?php endif; ?>
 
 <!-- ALERTA DE ASSETS FALTANTES -->

--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -64,7 +64,6 @@
   <script src="<?= asset('assets/js/wizard_stepper.js') ?>" defer></script>
   <script src="<?= asset('assets/js/dashboard.js') ?>" defer></script>
 <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
-  <link rel="stylesheet" href="<?= asset('assets/css/pages/_step6.css') ?>"><!-- <---- AGREGALO ACÁ -->
 
   <footer class="footer-schneider text-white mt-5">
     <div class="container py-4">


### PR DESCRIPTION
## Summary
- ensure step 6 CSS loads when the step is embedded
- remove global loading of step 6 CSS from layout

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `npm run build` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f9b94dcc832ca06acb4bad11b35b