### PR TITLE
Fix step 6 mobile layout

### DIFF
--- a/assets/css/pages/_step6.css
+++ b/assets/css/pages/_step6.css
@@ -99,7 +99,7 @@ body {
 .cards-grid [class*="col-"] {
   flex: 0 0 auto !important;
   margin: 0 !important;
-  width: auto !important;
+  width: 100% !important;
 }
 
 /* Controles deslizantes de configuración */
@@ -266,7 +266,7 @@ body.debug-mode .card {
 }
 
 /* Versión móvil: panel inferior para sliders */
-@media (width <= 991px) {
+@media (max-width: 991px) {
   .content-main {
     margin-bottom: 12rem;
   }

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -268,7 +268,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 <div class="container-fluid py-3 content-main">
   <!-- ENCABEZADO DE HERRAMIENTA -->
   <div class="container py-3">
-    <div class="row gx-3 mb-4 cards-grid">
+    <div class="gx-3 mb-4 cards-grid">
       <div class="col-12 col-lg-4 mb-3 area-tool">
         <div class="card h-100 shadow-sm">
           <div class="card-header text-center p-3">
@@ -294,7 +294,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 
   <!-- FILA: Sliders / Resultados / Radar -->
   <div class="container py-3">
-    <div class="row gx-3 mb-4 cards-grid">
+    <div class="gx-3 mb-4 cards-grid">
 
       <!-- 1) Ajustes (Sliders) -->
       <div class="col-12 col-lg-4 mb-3 area-sliders">
@@ -462,7 +462,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
             <h5 class="mb-0">Distribución Radar</h5>
           </div>
           <div class="card-body p-4 d-flex justify-content-center align-items-center">
-            <canvas id="radarChart" width="10%" height="50"></canvas>
+            <canvas id="radarChart" width="300" height="300"></canvas>
           </div>
         </div>
       </div>
@@ -473,7 +473,7 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
 
   <!-- ESPECIFICACIONES TÉCNICAS & IMAGEN VECTORIAL -->
   <div class="container py-3">
-    <div class="row gx-3 mb-4 cards-grid">
+    <div class="gx-3 mb-4 cards-grid">
 
       <div class="col-12 col-lg-4 mb-3">
         <div class="card h-100 shadow-sm">


### PR DESCRIPTION
## Summary
- adjust column styles for custom grid
- correct media query syntax for slider box
- drop Bootstrap `row` class from grid wrappers
- set radar chart canvas size

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm run lint` *(fails: Missing script)*
- `composer run-script lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685703e0e45c832c8b8bebba322bb423