### PR TITLE
Fix session-api csrf check

### DIFF
--- a/public/session-api.php
+++ b/public/session-api.php
@@ -11,8 +11,9 @@ require_once __DIR__ . '/../includes/security.php';
 session_start();
 require_debug_mode();
 
+// Validate CSRF token sent via header. Avoid undefined index warnings
 $token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
-if (!hash_equals($_SESSION['csrf_token'], $token)) {
+if (empty($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
     http_response_code(403);
     exit('CSRF fail');
 }


### PR DESCRIPTION
## Summary
- handle missing csrf token in `public/session-api.php`

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685713d39fa0832ca54d9a3b70752408