### PR TITLE
Fix closing div in step6

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -652,11 +652,10 @@ if (!file_exists($countUpLocal))    $assetErrors[] = 'CountUp.js faltante.';
     }
   });
 </script>
-  </div>
-
 <?php if (!$embedded): ?>
-</body>
-</html>
+  </div>
+  </body>
+  </html>
 <?php endif; ?>
 
 


### PR DESCRIPTION
## Summary
- wrap closing container div in the `!$embedded` condition so embedded mode isn't broken

## Testing
- `php -l views/steps/step6.php`
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857392fbc98832c87de7302337931af