### PR TITLE
Add documentation on session keys and callers

### DIFF
--- a/ajax/ajax_expert_result.php
+++ b/ajax/ajax_expert_result.php
@@ -3,7 +3,12 @@
  * File: ajax_expert_result.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: JS calculator on step 6 "Expert" view
+ * Important JSON fields:
+ *   - fz, vc, passes, D, Z, rpmMin, rpmMax, frMax
+ *   - thickness, ae, ap_slot, coefSeg, Kc11, mc, alpha, phi, eta
+ * Writes no session data
  * @TODO Extend documentation.
  */
 header('Content-Type: application/json');
@@ -15,7 +20,7 @@ if (!getenv('BASE_URL')) {
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../src/Utils/CNCCalculator.php';
 
-$data = json_decode(file_get_contents('php://input'), true);
+$data = json_decode(file_get_contents('php://input'), true); // parameters from JS
 
 try {
     $fz      = (float)$data['fz'];

--- a/ajax/get_tools.php
+++ b/ajax/get_tools.php
@@ -3,7 +3,12 @@
  * File: get_tools.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: auto mode step 3 to fetch recommended tools
+ * Reads session keys:
+ *   - $_SESSION['material_id']
+ *   - $_SESSION['strategy_id']
+ * Returns JSON list of tools
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
@@ -30,7 +35,7 @@ header('Content-Type: application/json');
 // (3) Cargar BD
 require_once __DIR__ . '/../includes/db.php';  // Ajusta si hiciera falta
 
-// (4) Comprobar sesión
+// (4) Comprobar sesión: valores establecidos en pasos anteriores
 $matRaw = $_SESSION['material_id'] ?? null;
 $strRaw = $_SESSION['strategy_id'] ?? null;
 if (!is_numeric($matRaw) || !is_numeric($strRaw)) {

--- a/ajax/paso_minimo_ajax.php
+++ b/ajax/paso_minimo_ajax.php
@@ -3,14 +3,17 @@
  * File: paso_minimo_ajax.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: legacy demo page for minimum pass calculations
+ * Important JSON fields: fz, vc, passes, D, Z, thickness, ae, frMax, etc.
+ * Writes no session data
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
 header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 
-$data = json_decode(file_get_contents('php://input'), true);
+$data = json_decode(file_get_contents('php://input'), true); // parameters from JS
 if (!isset($data['fz'],$data['vc'],$data['passes'])) {
     http_response_code(400);
     echo json_encode(['error'=>'Parámetros inválidos']);

--- a/ajax/step6_ajax_calculate.php
+++ b/ajax/step6_ajax_calculate.php
@@ -3,7 +3,10 @@
  * File: step6_ajax_calculate.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: experimental step6 calculator in JS
+ * Important JSON fields: fzCurrent, vcCurrent, passes and params[*]
+ * Reads no session data
  * @TODO Extend documentation.
  */
 // File: C:\xampp\htdocs\wizard-stepper_git\ajax\step6_ajax_calculate.php
@@ -16,7 +19,7 @@ if (!getenv('BASE_URL')) {
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 header('Content-Type: application/json; charset=UTF-8');
 
-$input = file_get_contents('php://input');
+$input = file_get_contents('php://input'); // JSON payload from step6.js
 if (!$input) {
     http_response_code(400);
     echo json_encode(['error' => 'No data received']);

--- a/ajax/step6_ajax_legacy_minimal.php
+++ b/ajax/step6_ajax_legacy_minimal.php
@@ -3,7 +3,10 @@
  * File: step6_ajax_legacy_minimal.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: assets/js/step6.js to compute machining parameters
+ * Important JSON fields: fz, vc, ae, passes, thickness, D, Z, params[*]
+ * Uses session key: $_SESSION['csrf_token'] for validation
  * @TODO Extend documentation.
  */
 /**
@@ -28,7 +31,7 @@ header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 
 // Iniciar sesión para CSRF
-session_start();
+session_start(); // ensures $_SESSION['csrf_token'] is available
 
 // 0. CSRF: validar token enviado en header X-CSRF-Token
 $token = (string)($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');

--- a/ajax/step_minimo_ajax.php
+++ b/ajax/step_minimo_ajax.php
@@ -3,7 +3,10 @@
  * File: step_minimo_ajax.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: legacy "step minimo" calculator
+ * Important JSON fields: fz, vc, ae, passes, thickness, D, Z, params[*]
+ * Uses session key: $_SESSION['csrf_token'] for validation
  * @TODO Extend documentation.
  */
 /**
@@ -22,17 +25,17 @@ header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 
 // Iniciar sesión para CSRF
-session_start();
+session_start(); // needed to access $_SESSION['csrf_token']
 
 // 0. CSRF: validar token enviado en header X-CSRF-Token
-$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? ''; // token provided via header
 if (empty($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $csrfHeader)) {
     http_response_code(403);
     echo json_encode(['success' => false, 'error' => 'Token CSRF inválido']);
     exit;
 }
 
-// 1. Leer entrada JSON
+// 1. Leer entrada JSON enviado por step_minimo.js
 $input = json_decode(file_get_contents('php://input'), true);
 if (!is_array($input)) {
     http_response_code(400);

--- a/ajax/strategy_ajax.php
+++ b/ajax/strategy_ajax.php
@@ -3,7 +3,12 @@
  * File: strategy_ajax.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: step 2/3 pages to retrieve available strategies for a tool
+ * Important GET params:
+ *   - tool_id
+ *   - tool_table
+ *   - machining_type_id
  * @TODO Extend documentation.
  */
 // strategy_ajax.php
@@ -15,12 +20,13 @@ if (!getenv('BASE_URL')) {
 require_once __DIR__ . '/../src/Config/AppConfig.php';
 require_once __DIR__ . '/../includes/db.php';
 
+// Basic sanity check to avoid direct access
 if (!isset($_GET['ajax']) || $_GET['ajax'] !== '1') {
     http_response_code(400);
     exit('Bad request');
 }
 
-$toolId = isset($_GET['tool_id']) ? (int)$_GET['tool_id'] : 0;
+$toolId = isset($_GET['tool_id']) ? (int)$_GET['tool_id'] : 0; // tool identifier
 $toolTable = $_GET['tool_table'] ?? '';
 $machiningTypeId = isset($_GET['machining_type_id']) ? (int)$_GET['machining_type_id'] : 0;
 

--- a/ajax/tools_ajax.php
+++ b/ajax/tools_ajax.php
@@ -3,7 +3,10 @@
  * File: tools_ajax.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: manual tool browser for searching tools
+ * Important GET params include many filter names (brand, material_id, ...)
+ * No session data is needed
  * @TODO Extend documentation.
  */
 // tools_ajax.php - Devuelve lista de herramientas filtradas (sin autenticación)
@@ -33,6 +36,7 @@ foreach ($pdo->query("SELECT id, code FROM series") as $s) {
 // 1) Normalize GET filters
 $f = [];
 $qText = '';
+// Parse query-string filters coming from the tool browser
 foreach ($_GET as $k => $v) {
     if ($k === 'q') {
         $qText = trim($v);

--- a/ajax/tools_scroll.php
+++ b/ajax/tools_scroll.php
@@ -3,7 +3,11 @@
  * File: tools_scroll.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: infinite scroll tool browser
+ * Important GET params:
+ *   - material_id, strategy_id, page, per_page
+ * Uses session keys for defaults and CSRF token via header
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
@@ -27,6 +31,7 @@ header('Pragma: no-cache');
 startSecureSession();
 
 $token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+// Protect listing with the same CSRF token as the wizard
 if (!validateCsrfToken($token)) {
     http_response_code(403);
     echo json_encode(['error' => 'csrf']);
@@ -39,6 +44,7 @@ $page       = filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT) ?: 1;
 $perPage    = filter_input(INPUT_GET, 'per_page', FILTER_VALIDATE_INT) ?: 12;
 
 if ($materialId === false || $materialId === null) {
+    // fallback to session values from previous steps
     $materialId = $_SESSION['material_id'] ?? null;
 }
 if ($strategyId === false || $strategyId === null) {

--- a/api/restore_progress.php
+++ b/api/restore_progress.php
@@ -3,7 +3,12 @@
  * File: restore_progress.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: JS helper to restore wizard progress from localStorage
+ * Important POST params:
+ *   - progress  Desired wizard step number
+ * Writes session key:
+ *   - $_SESSION['wizard_progress']
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
@@ -71,6 +76,7 @@ if ($progressRaw < 0 || $progressRaw > 6) {
 }
 
 // (D) Fijar en sesión y devolver éxito
+// store the chosen step so wizard.php can resume correctly
 $_SESSION['wizard_progress'] = $progressRaw;
 dbgLocal("wizard_progress restaurado a $progressRaw");
 echo json_encode([

--- a/public/export.php
+++ b/public/export.php
@@ -3,7 +3,11 @@
  * File: export.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: front-end export action (step 6 page)
+ * Important session keys:
+ *   - $_SESSION['csrf_token']   CSRF token validated here
+ *   - Various wizard_* values are streamed to the output
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
@@ -19,6 +23,7 @@ session_start();
 require_debug_mode();
 
 $token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+// Validate download request using the CSRF token stored in the session
 if (!hash_equals($_SESSION['csrf_token'], $token)) {
     http_response_code(403);
     exit('CSRF fail');

--- a/public/export_json.php
+++ b/public/export_json.php
@@ -3,7 +3,11 @@
  * File: export_json.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: front-end export action (JSON variant)
+ * Important session keys:
+ *   - $_SESSION['csrf_token'] validates this download
+ *   - All current wizard_* values are included in the JSON
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
@@ -19,6 +23,7 @@ session_start();
 require_debug_mode();
 
 $token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+// Validate request with session's CSRF token
 if (!hash_equals($_SESSION['csrf_token'], $token)) {
     http_response_code(403);
     exit('CSRF fail');

--- a/public/load-step.php
+++ b/public/load-step.php
@@ -3,7 +3,15 @@
  * File: load-step.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: wizard.php via asynchronous requests
+ * Important GET params:
+ *   - step    Requested wizard step
+ *   - debug   Enable verbose output
+ * Important session keys used:
+ *   - $_SESSION['wizard_state']
+ *   - $_SESSION['wizard_progress']
+ *   - $_SESSION['tool_mode']
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
@@ -65,8 +73,10 @@ $requestedStep = filter_input(INPUT_GET, 'step', FILTER_VALIDATE_INT);
 // ─────────────────────────────────────────────────────────────
 // [6] VERIFICAR ESTADO DE SESIÓN (PERMITIR PASO 1 INICIAL)
 // ─────────────────────────────────────────────────────────────
+// wizard_state is created in wizard.php when starting the flow
 if (($_SESSION['wizard_state'] ?? '') !== 'wizard') {
     if ($requestedStep === 1) {
+        // Initialize wizard state and progress for first step
         $_SESSION['wizard_state']    = 'wizard';
         $_SESSION['wizard_progress'] = $_SESSION['wizard_progress'] ?? 1;
         session_regenerate_id(true);
@@ -94,7 +104,7 @@ dbg("📥 Paso solicitado: {$step}");
 // ─────────────────────────────────────────────────────────────
 // [7] VERIFICAR PROGRESO DEL USUARIO
 // ─────────────────────────────────────────────────────────────
-$currentProgress = (int)($_SESSION['wizard_progress'] ?? 0);
+$currentProgress = (int)($_SESSION['wizard_progress'] ?? 0); // progress set in handle-step.php
 dbg("🔢 Progreso actual (sesión): {$currentProgress}");
 
 $maxAllowedStep = $currentProgress + 1;
@@ -107,7 +117,7 @@ if ($step > $maxAllowedStep) {
 // ─────────────────────────────────────────────────────────────
 // [8] DETECTAR MODO (auto vs manual)
 // ─────────────────────────────────────────────────────────────
-$modeRaw = $_SESSION['tool_mode'] ?? 'manual';
+$modeRaw = $_SESSION['tool_mode'] ?? 'manual'; // set during step selection
 $mode    = ($modeRaw === 'auto') ? 'auto' : 'manual';
 dbg("🧭 Modo actual: {$mode}");
 

--- a/public/reset.php
+++ b/public/reset.php
@@ -3,7 +3,9 @@
  * File: reset.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: user clicking the "Reset" link
+ * Important session keys affected: all wizard_* values are cleared
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
@@ -42,6 +44,7 @@ header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');
 
 // [C] Iniciar sesión si aún no está activa
+// Create a new session to access and later remove existing data
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_set_cookie_params([
         'lifetime' => 0,
@@ -56,6 +59,7 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 dbg('🔐 Sesión activa');
 
 // [D] Borrar todo el estado de sesión
+// Clear all wizard-related state
 $_SESSION = [];
 session_unset();
 session_destroy();

--- a/public/session-api.php
+++ b/public/session-api.php
@@ -3,7 +3,10 @@
  * File: session-api.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: debugging tools to inspect the session
+ * Important session keys returned: entire $_SESSION array
+ * Requires header X-CSRF-Token matching $_SESSION['csrf_token']
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
@@ -20,6 +23,7 @@ require_debug_mode();
 
 // Validate CSRF token sent via header. Avoid undefined index warnings
 $token = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+// Only allow reading the session when the CSRF token matches
 if (empty($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
     http_response_code(403);
     exit('CSRF fail');

--- a/public/tools_facets.php
+++ b/public/tools_facets.php
@@ -3,7 +3,9 @@
  * File: tools_facets.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: JS tool browser to retrieve available filter values
+ * Reads no session keys; no POST parameters
  * @TODO Extend documentation.
  */
 /**

--- a/public/tools_search.php
+++ b/public/tools_search.php
@@ -3,7 +3,10 @@
  * File: tools_search.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: JS tool search page
+ * Important GET params: 'q', 'diameter' and various filters
+ * No session data is required
  * @TODO Extend documentation.
  */
 // tools_search.php
@@ -18,6 +21,7 @@ require_once __DIR__ . '/../includes/db.php';
 header('Content-Type: application/json; charset=utf-8');
 
 // Recibir filtros y búsqueda
+// Text search and optional diameter filter
 $q = $_GET['q'] ?? '';
 $diameter = $_GET['diameter'] ?? '';
 

--- a/src/Controller/AutoToolRecommenderController.php
+++ b/src/Controller/AutoToolRecommenderController.php
@@ -3,7 +3,14 @@
  * File: AutoToolRecommenderController.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: views/steps/auto/step3.php
+ * Important session keys handled:
+ *   - $_SESSION['wizard_state']    Current wizard state
+ *   - $_SESSION['wizard_progress'] Wizard progress counter
+ *   - $_SESSION['material_id']     Selected material ID
+ *   - $_SESSION['strategy_id']     Selected strategy ID
+ *   - $_SESSION['thickness']       Material thickness
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
@@ -63,14 +70,18 @@ class AutoToolRecommenderController
     {
         self::initSession();
 
+        // $_SESSION['wizard_state'] is set by wizard.php when the user
+        // enters the wizard flow
         if (($_SESSION['wizard_state'] ?? '') !== 'wizard') {
             throw new RuntimeException('Estado de wizard inválido');
         }
 
+        // check that $_SESSION['material_id'] was stored in a previous step
         if (empty($_SESSION['material_id']) || !is_numeric($_SESSION['material_id'])) {
             throw new RuntimeException('Falta material_id en la sesión');
         }
 
+        // $_SESSION['strategy_id'] is defined when selecting the machining strategy
         if (empty($_SESSION['strategy_id']) || !is_numeric($_SESSION['strategy_id'])) {
             throw new RuntimeException('Falta strategy_id en la sesión');
         }
@@ -105,6 +116,7 @@ class AutoToolRecommenderController
     public static function enforceWizardProgress(int $minProgress): void
     {
         self::initSession();
+        // wizard.php stores the current state and progress in session
         $state    = $_SESSION['wizard_state'] ?? '';
         $progress = (int)($_SESSION['wizard_progress'] ?? 0);
 
@@ -125,6 +137,7 @@ class AutoToolRecommenderController
     {
         self::initSession();
 
+        // These keys are written during previous wizard steps
         $required = ['material_id', 'strategy_id', 'thickness'];
         foreach ($required as $key) {
             if (!isset($_SESSION[$key]) || $_SESSION[$key] === '') {

--- a/src/Controller/ExpertResultController.php
+++ b/src/Controller/ExpertResultController.php
@@ -3,7 +3,18 @@
  * File: ExpertResultController.php
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
- * Related files: See others in this project.
+ *
+ * Called by: views/steps/step6.php
+ * Important session keys read:
+ *   - $_SESSION['tool_table']    Current tool table
+ *   - $_SESSION['tool_id']       Selected tool identifier
+ *   - $_SESSION['material']      Material ID
+ *   - $_SESSION['trans_id']      Machine/operation ID
+ *   - $_SESSION['rpm_min']       Minimum RPM allowed
+ *   - $_SESSION['rpm_max']       Maximum RPM allowed
+ *   - $_SESSION['fr_max']        Maximum feed rate
+ *   - $_SESSION['thickness']     Material thickness
+ *   - $_SESSION['hp']            Available machine horsepower
  * @TODO Extend documentation.
  */
 /**
@@ -48,6 +59,7 @@ class ExpertResultController
     public static function getResultData(\PDO $pdo, array $session): array
     {
         // 1) Validar datos de sesión
+        // These session keys are populated across earlier wizard steps
         $required = [
             'tool_table','tool_id','material','trans_id',
             'rpm_min','rpm_max','fr_max','thickness','hp'
@@ -60,15 +72,16 @@ class ExpertResultController
         }
 
         // 2) Extraer parámetros
+        // Values come from $_SESSION as passed by the step 5 form
         $tbl        = (string)$session['tool_table'];
         $toolId     = (int)$session['tool_id'];
         $materialId = (int)$session['material'];
         $transId    = (int)$session['trans_id'];
-        $rpmMin     = (float)$session['rpm_min'];
-        $rpmMax     = (float)$session['rpm_max'];
-        $frMax      = (float)$session['fr_max'];
-        $thickness  = (float)$session['thickness'];
-        $hpAvail    = (float)$session['hp'];
+        $rpmMin     = (float)$session['rpm_min'];   // limits configured on step 5
+        $rpmMax     = (float)$session['rpm_max'];   // limits configured on step 5
+        $frMax      = (float)$session['fr_max'];    // feed rate maximum
+        $thickness  = (float)$session['thickness']; // part thickness
+        $hpAvail    = (float)$session['hp'];        // machine horsepower
 
         try {
             // 3) Datos de la herramienta


### PR DESCRIPTION
## Summary
- document important session variables and who calls each controller or endpoint
- clarify CSRF handling and POST parameters with inline comments

## Testing
- `php` or `composer` not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68573dc33a9c832c8e95d3c0a2ed5b7b