### PR TITLE
Update step6 CSP header

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -39,7 +39,11 @@ if (!$embedded) {
     header("Permissions-Policy: geolocation=(), microphone=()");
     header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
     header('Pragma: no-cache');
-    header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';");
+    header(
+        "Content-Security-Policy: default-src 'self';"
+        . " script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;"
+        . " style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;"
+    );
 }
 
 // ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- update security headers in `views/steps/step6.php` to allow loading fallback CDN styles/scripts

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `curl -I https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_685753492f94832c897fcddf0f39f527