### PR TITLE
Fix duplicate CSS include

### DIFF
--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -70,7 +70,6 @@
   <script>feather.replace();</script>
   <script src="<?= asset('assets/js/wizard_stepper.js') ?>" defer></script>
   <script src="<?= asset('assets/js/dashboard.js') ?>" defer></script>
-<link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
 
   <footer class="footer-schneider text-white mt-5">
     <div class="container py-4">


### PR DESCRIPTION
## Summary
- remove redundant wizard.css link

## Testing
- `npm run lint:css` *(fails: comment-empty-line-before and other stylelint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685760b8de14832ca418dc2ad3617595