### PR TITLE
Fix missing common CSS in embedded Step6

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -281,6 +281,7 @@ if (!file_exists($countUpLocal))   $assetErrors[] = 'CountUp.js faltante.';
 <body>
 <div class="container py-4">
 <?php else: ?>
+  <link rel="stylesheet" href="<?= asset('assets/css/step-common.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/pages/_step6.css') ?>">
 <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- in embedded mode for step 6, also load `step-common.css`

## Testing
- `vendor/bin/phpunit -q` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68576274b2ac832c997227cc1ec1a4e6