### PR TITLE
Fix base url on direct reload

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -9,6 +9,12 @@ declare(strict_types=1);
 
 use App\Controller\ExpertResultController;
 
+// Ensure BASE_URL is correctly set when this view is loaded directly
+if (!getenv('BASE_URL')) {
+    $base = rtrim(dirname(dirname(dirname($_SERVER['SCRIPT_NAME']))), '/');
+    putenv('BASE_URL=' . $base);
+}
+
 // ────────────────────────────────────────────────────────────────
 // Utilidades / helpers
 // ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- set `BASE_URL` when step6 runs standalone to fix missing assets

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857643a5538832c96a58d34f066a877