### PR TITLE
Ensure BASE_URL consistently set

### DIFF
--- a/src/Config/AppConfig.php
+++ b/src/Config/AppConfig.php
@@ -14,9 +14,10 @@ declare(strict_types=1);
 // ---------------------------------------------------------------------------
 
 if (!defined('BASE_URL')) {
-    // 🌐 BASE_URL → solo path (funciona bien en XAMPP y producción)
-    $basePath = getenv('BASE_URL') ?: dirname($_SERVER['SCRIPT_NAME']);
-    define('BASE_URL', rtrim($basePath, '/'));
+    $envBase = getenv('BASE_URL');
+    $base    = $envBase !== false ? $envBase
+                                  : dirname($_SERVER['SCRIPT_NAME']);
+    define('BASE_URL', rtrim($base, '/'));
 }
 
 if (!defined('BASE_HOST')) {
@@ -30,7 +31,9 @@ if (!defined('BASE_HOST')) {
 if (!function_exists('asset')) {
     function asset(string $path): string
     {
-        return BASE_URL . '/' . ltrim($path, '/');
+        return BASE_URL === ''
+            ? '/' . ltrim($path, '/')
+            : BASE_URL . '/' . ltrim($path, '/');
     }
 }
 

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -7,20 +7,13 @@
 
 declare(strict_types=1);
 
-use App\Controller\ExpertResultController;
+require_once __DIR__ . '/../../src/Config/AppConfig.php';
 
-// Ensure BASE_URL is correctly set when this view is loaded directly
-if (!getenv('BASE_URL')) {
-    $base = rtrim(dirname(dirname(dirname($_SERVER['SCRIPT_NAME']))), '/');
-    putenv('BASE_URL=' . $base);
-}
+use App\Controller\ExpertResultController;
 
 // ────────────────────────────────────────────────────────────────
 // Utilidades / helpers
 // ────────────────────────────────────────────────────────────────
-
-
-require_once __DIR__ . '/../../src/Config/AppConfig.php';
 
 require_once __DIR__ . '/../../includes/wizard_helpers.php';
 

--- a/wizard.php
+++ b/wizard.php
@@ -7,6 +7,9 @@
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
+if (!getenv('BASE_URL')) {
+    putenv('BASE_URL=' . rtrim(dirname($_SERVER['SCRIPT_NAME']), '/'));
+}
 require_once __DIR__ . '/src/Config/AppConfig.php';
 /**
  * File: wizard.php


### PR DESCRIPTION
## Summary
- import AppConfig early in Step 6
- compute BASE_URL in AppConfig from env or request path
- expose helper `asset()` from one place
- set BASE_URL from wizard.php before requiring config

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68577486e43c832c9ae8c6c1c6c1a4c1