### PR TITLE
Fix BASE_URL path in step6 view

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -8,7 +8,13 @@
 declare(strict_types=1);
 
 if (!getenv('BASE_URL')) {
-    putenv('BASE_URL=' . rtrim(dirname($_SERVER['SCRIPT_NAME']), '/'));
+    // Sube 3 niveles: /views/steps/step6.php → /
+    putenv(
+        'BASE_URL=' . rtrim(
+            dirname(dirname(dirname($_SERVER['SCRIPT_NAME']))),
+            '/'
+        )
+    );
 }
 require_once __DIR__ . '/../../src/Config/AppConfig.php';
 


### PR DESCRIPTION
## Summary
- correct BASE_URL initialization in `views/steps/step6.php` so assets load

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68577cedf67c832c81b19a419ee3fb98