### PR TITLE
Add CSS auditing workflow and build scripts

### DIFF
--- a/.github/workflows/css-audit.yml
+++ b/.github/workflows/css-audit.yml
@@ -1,0 +1,39 @@
+name: CSS Audit
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  css-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run audit:css
+      - run: npm run build:css
+      - name: Compare CSS size
+        run: |
+          SIZE=$(stat -c%s dist/style.min.css)
+          echo "size=$SIZE" >> $GITHUB_OUTPUT
+        id: size
+      - uses: actions/upload-artifact@v4
+        with:
+          name: css-reports
+          path: reports/
+      - name: Fail if CSS increased more than 5%
+        run: |
+          LAST=$(curl -sL "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/latest/download/style.min.css" | wc -c || echo 0)
+          CURR=$(stat -c%s dist/style.min.css)
+          THRESHOLD=$(( LAST + LAST / 20 ))
+          if [ $CURR -gt $THRESHOLD ]; then
+            echo "CSS size increased more than 5%" && exit 1
+          fi
+      - name: Notify
+        if: failure()
+        run: echo "Send notification with reports"

--- a/README.md
+++ b/README.md
@@ -52,14 +52,34 @@ vendor/bin/phpunit
 ```
 
 ## Auditing unused CSS
-
-Run the PurgeCSS audit script to see which selectors are not used by the PHP views or JavaScript modules:
+Run the PurgeCSS audit script to see unused selectors and generate a report:
 
 ```bash
-node scripts/purgecss-audit.js
+npm run audit:css
 ```
 
-The script generates `reports/report-unused-selectors.json` with all removed selectors.
+For a LightningCSS analysis run:
+
+```bash
+npm run analyze:css
+```
+
+Reports are saved under `reports/`.
+
+## Building optimized CSS
+
+Generate a production bundle and validate size:
+
+```bash
+npm run build:css
+```
+
+## Keeping CSS Lean
+
+- Remove unused selectors regularly with `npm run audit:css`.
+- Review `reports/unused-selectors.json` and clean obsolete rules.
+- Keep ITCSS comments like `/*! ITCSS */` to maintain structure.
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "chokidar-cli": "^3.0.0",
     "concurrently": "^9.1.2",
     "eslint": "^9.29.0",
+    "lightningcss": "^1.23.0",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
     "postcss-preset-env": "^10.2.3",
@@ -23,7 +24,10 @@
   "scripts": {
     "build": "postcss 'assets/css/**/*.css' -r",
     "watch": "chokidar 'assets/css/**/*.css' -c \"npm run build\"",
-    "lint:css": "stylelint 'assets/css/**/*.css'"
+    "lint:css": "stylelint 'assets/css/**/*.css'",
+    "audit:css": "node scripts/purgecss-audit.js",
+    "analyze:css": "node scripts/lightningcss-report.js",
+    "build:css": "node scripts/build-css.js"
   },
   "keywords": [],
   "author": "",

--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  content: [
+    './views/**/*.php',
+    './public/**/*.php',
+    './src/**/*.php',
+    './assets/js/**/*.js',
+    './**/*.html'
+  ],
+  css: ['assets/css/**/*.css'],
+  safelist: {
+    standard: [/^is-/, /^has-/],
+    deep: [/^vue-/, /^react-/],
+    greedy: ['active', 'open']
+  }
+};

--- a/scripts/build-css.js
+++ b/scripts/build-css.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { glob } = require('glob');
+
+const MAX_SIZE_KB = 50; // size limit
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+function build() {
+  fs.rmSync('dist', { recursive: true, force: true });
+  fs.mkdirSync('dist', { recursive: true });
+
+  run("postcss 'assets/css/**/*.css' -d dist");
+  run("npx purgecss --config purgecss.config.js --css dist/**/*.css --output dist");
+
+  const files = glob.sync('dist/**/*.css');
+  const concatenated = files.map(f => fs.readFileSync(f, 'utf8')).join('\n');
+  fs.writeFileSync('dist/combined.css', concatenated);
+  run('npx lightningcss dist/combined.css -o dist/style.min.css --minify');
+
+  const size = fs.statSync(path.join('dist', 'style.min.css')).size / 1024;
+  if (size > MAX_SIZE_KB) {
+    console.error(`CSS size ${size.toFixed(2)}KB exceeds ${MAX_SIZE_KB}KB limit`);
+    process.exit(1);
+  }
+}
+
+build();

--- a/scripts/lightningcss-report.js
+++ b/scripts/lightningcss-report.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+function run() {
+  const output = execSync('npx lightningcss assets/css --analyze', { encoding: 'utf8' });
+  fs.mkdirSync('reports', { recursive: true });
+  fs.writeFileSync('reports/lightningcss-report.json', JSON.stringify({ analysis: output }, null, 2));
+}
+
+run();

--- a/scripts/purgecss-audit.js
+++ b/scripts/purgecss-audit.js
@@ -4,18 +4,18 @@ const path = require('path');
 const { glob } = require('glob');
 const postcss = require('postcss');
 const purgecss = require('@fullhuman/postcss-purgecss').default;
+const purgeConfig = require('../purgecss.config');
 
 async function audit() {
   // Skip minified files which might trigger parser errors
-  const cssFiles = glob.sync('assets/css/**/*.css', {
-    ignore: ['**/*.min.css']
-  });
+  const cssFiles = glob.sync(purgeConfig.css, { ignore: ['**/*.min.css'] });
   const report = {};
   for (const file of cssFiles) {
     const css = fs.readFileSync(file, 'utf8');
     const result = await postcss([
       purgecss({
-        content: ['views/**/*.php', 'assets/js/**/*.js'],
+        content: purgeConfig.content,
+        safelist: purgeConfig.safelist,
         rejected: true
       })
     ]).process(css, { from: file });
@@ -35,7 +35,7 @@ async function audit() {
   }
   fs.mkdirSync('reports', { recursive: true });
   fs.writeFileSync(
-    path.join('reports', 'report-unused-selectors.json'),
+    path.join('reports', 'unused-selectors.json'),
     JSON.stringify(report, null, 2) + '\n'
   );
 }


### PR DESCRIPTION
## Summary
- add purgecss config for removing unused selectors
- integrate LightningCSS analysis script
- add build script that enforces size limits
- document CSS auditing and building
- add GitHub Actions workflow for CSS audit

## Testing
- `npm run lint:css`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6857a231f210832ca18452115220c42c