### PR TITLE
Fix duplicated step6 styles and slider vars

### DIFF
--- a/assets/css/components/_slider.css
+++ b/assets/css/components/_slider.css
@@ -7,6 +7,11 @@
 
 /* Estilos reutilizables para controles tipo slider */
 
+:root {
+  --val: 0;
+  --step-pct: 10;
+}
+
 /* Contenedor del slider y variables de valor */
 .slider-wrap {
   --val: 0;        /* valor actual 0-100 */
@@ -101,9 +106,14 @@ input[type="range"].form-range::-ms-track {
   padding: 0.1rem 0.35rem;
   position: absolute;
   top: -1.6rem;
+
   transform: translateX(-50%);
   white-space: nowrap;
 }
+.slider-tick {
+  position: absolute;
+}
+
 
 @keyframes shake {
   0%,100% { transform: translateX(-50%) translateY(0); }

--- a/assets/css/components/main.css
+++ b/assets/css/components/main.css
@@ -13,3 +13,4 @@
 @import url('./_button.css');
 @import url('./_slider.css');
 @import url('./_fresa-card.css');
+@import url('./step6.css');

--- a/assets/css/components/step6.css
+++ b/assets/css/components/step6.css
@@ -1,6 +1,6 @@
 
 /*
- * File: assets/css/pages/_step6.css  (versión pulida)
+ * File: assets/css/pages/step6.css  (versión pulida)
  * Responsabilidad: Estilos exclusivos del Paso 6 del Wizard CNC.
  * Mantiene la misma apariencia que tu borrador original, saneando duplicados y
  * evitando side‑effects sobre otros pasos. No requiere clases envolventes.
@@ -8,10 +8,6 @@
  * → Variables globales definidas en settings/_variables.css
  * → No sobreescribe reglas de stepper.css ni Bootstrap
  */
-
-@import url('../settings/_variables.css');
-@import url('../generic/_reset.css');
-@import url('../elements/_typography.css');
 
 /* =======================  Paleta y texto base  ====================== */
 body {

--- a/docs/file_overview.md
+++ b/docs/file_overview.md
@@ -36,7 +36,7 @@ This document lists source files with certain extensions and their roles in the 
 | ./assets/css/components/_step2.css | partial/component |
 | ./assets/css/components/_step3.css | partial/component |
 | ./assets/css/components/_step5.css | partial/component |
-| ./assets/css/components/_step6.css | partial/component |
+| ./assets/css/components/step6.css | partial/component |
 | ./assets/css/components/step3_auto_tool_recommendation.css | view/template |
 | ./assets/css/objects/step-common.css | view/template |
 | ./assets/css/objects/stepper.css | view/template |

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -4,6 +4,8 @@
  * Descripción: Paso 6 – Resultados expertos del Wizard CNC
  * Versión pulida: se corrigieron nombres de IDs, clases CSS, chequeos de constantes y algunas advertencias PHP.
  */
+// Para pruebas AJAX: fetch("public/load-step.php?step=6")
+
 
 declare(strict_types=1);
 
@@ -274,12 +276,6 @@ if (!file_exists($countUpLocal))   $assetErrors[] = 'CountUp.js faltante.';
         onload="console.log('✅ step-common.css cargado')"
         onerror="console.error('❌ step-common.css NO cargó')">
 
-  <link id="css-step6"
-        rel="stylesheet"
-        href="<?= asset('assets/css/components/_step6.css') ?>"
-        onload="console.log('✅ _step6.css cargado')"
-        onerror="console.error('❌ _step6.css NO cargó')">
-
   <script>
     window.BASE_URL  = <?= json_encode(BASE_URL) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
@@ -288,7 +284,7 @@ if (!file_exists($countUpLocal))   $assetErrors[] = 'CountUp.js faltante.';
   <?php
   echo '<!-- main.css = '.asset('assets/css/components/main.css').' -->';
   echo '<!-- step-common.css = '.asset('assets/css/objects/step-common.css').' -->';
-  echo '<!-- _step6.css = '.asset('assets/css/components/_step6.css').' -->';
+  echo '<!-- step6.css = '.asset('assets/css/components/step6.css').' -->';
   ?>
 </head>
 


### PR DESCRIPTION
## Summary
- keep `step6.css` under components and import from main
- define slider variables globally and add `.slider-tick`
- remove per-page step6 stylesheet include
- document AJAX testing snippet

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581b96bb30832c9d8023c6a7e46b85