### PR TITLE
Fix card background for email

### DIFF
--- a/assets/css/components/_common.css
+++ b/assets/css/components/_common.css
@@ -37,3 +37,25 @@
   background-color: #38bdf8 !important;
   color: #0c4a6e !important;
 }
+
+/* Card backgrounds respect email styles */
+.card,
+.config-card-static,
+.notes-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.card-header {
+  background: var(--bg-header);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--accent-color);
+  font-weight: 600;
+}
+
+.card.h-100 {
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
## Summary
- tweak CSS card background so stepper matches email backgrounds

## Testing
- `npm run lint:css`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582a498718832c9fd02d2c614806db