### PR TITLE
Fix reset page stylesheet path

### DIFF
--- a/public/reset.php
+++ b/public/reset.php
@@ -101,7 +101,7 @@ dbg('🔄 Nueva sesión limpia generada');
   <meta charset="UTF-8">
   <title>Reiniciando Wizard CNC...</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="<?= asset('assets/css/base/reset.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/generic/reset.css') ?>">
   <script>
     const BASE_URL = <?= json_encode(BASE_URL) ?>;
   </script>


### PR DESCRIPTION
## Summary
- correct the CSS path in `public/reset.php` so the reset page uses the existing stylesheet

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582a498718832c9fd02d2c614806db