### PR TITLE
Fix transparent background when embedded

### DIFF
--- a/views/partials/styles.php
+++ b/views/partials/styles.php
@@ -15,4 +15,7 @@ foreach ($styles as $href) {
     $url = str_starts_with($href, 'http') ? $href : asset($href);
     echo '<link rel="stylesheet" href="'.$url.'">'.PHP_EOL;
 }
+if ($embedded) {
+    echo '<style>body{background-color:transparent!important;}</style>'.PHP_EOL;
+}
 ?>


### PR DESCRIPTION
## Summary
- ensure wizard pages respect parent page background when embedded

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68582a498718832c9fd02d2c614806db