### PR TITLE
Fix step6 init and listener

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -237,6 +237,8 @@ window.initStep6 = function () {
   updatePasadasSlider();
   updatePasadasInfo();
   recalc();
-  window.addEventListener('error', ev => showError(`JS: ${ev.message}`));
+  if (!window.step6ErrorHandlerAdded) {
+    window.addEventListener('error', ev => showError(`JS: ${ev.message}`));
+    window.step6ErrorHandlerAdded = true;
+  }
 };
-window.initStep6();


### PR DESCRIPTION
## Summary
- remove self-initialization from `step6.js`
- guard global error handler so it's only attached once

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `node /tmp/test_step6.js` to verify single error handler

------
https://chatgpt.com/codex/tasks/task_e_68582cc3f998832c8bf0cbe32a432e9e