### PR TITLE
Remove debug comment from Step 6 view

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -279,11 +279,6 @@ if (!file_exists($countUpLocal))   $assetErrors[] = 'CountUp.js faltante.';
     window.BASE_URL  = <?= json_encode(BASE_URL) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
   </script>
-  <!-- DEBUG — eliminar después -->
-  <?php
-  echo '<!-- main.css = '.asset('assets/css/components/main.css').' -->';
-  echo '<!-- step-common.css = '.asset('assets/css/objects/step-common.css').' -->';
-  ?>
 </head>
 
 


### PR DESCRIPTION
## Summary
- remove `<!-- DEBUG — eliminar después -->` block from `step6.php`

## Testing
- `./vendor/bin/phpunit` *(fails: file not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582da03f44832c96808710221e71e8