### PR TITLE
Fix step title styling for early wizard steps

### DIFF
--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -203,6 +203,7 @@ dbg('children', $children);
     $styles = [
       'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css',
       'assets/css/generic/material.css',
+      'assets/css/objects/step-common.css',
     ];
     $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
     include __DIR__ . '/../../partials/styles.php';

--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -168,6 +168,7 @@ try {
     $styles = [
       'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css',
       'assets/css/components/step3_auto_tool_recommendation.css',
+      'assets/css/objects/step-common.css',
     ];
     $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
     include __DIR__ . '/../../partials/styles.php';

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -150,6 +150,7 @@ if($tool){
       'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css',
       'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css',
       'assets/css/components/_step2.css',
+      'assets/css/objects/step-common.css',
     ];
     $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
     include __DIR__ . '/../../partials/styles.php';

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -140,6 +140,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css',
       'assets/css/components/_step1.css',
       'assets/css/components/_manual.css',
+      'assets/css/objects/step-common.css',
     ];
     $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
     include __DIR__ . '/../../partials/styles.php';

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -135,6 +135,7 @@ if ($tool) {
     $styles = [
       'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css',
       'assets/css/components/_step2.css',
+      'assets/css/objects/step-common.css',
     ];
     $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
     include __DIR__ . '/../../partials/styles.php';

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -148,6 +148,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
   $styles = [
     'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css',
     'assets/css/generic/material.css',
+    'assets/css/objects/step-common.css',
   ];
   $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
   include __DIR__ . '/../../partials/styles.php';


### PR DESCRIPTION
## Summary
- include step-common.css in manual steps 1,2,4
- include step-common.css in automatic steps 1,3,4

## Testing
- `vendor/bin/phpunit`
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68582dd9aa24832cad85486808a66824