### PR TITLE
Fix step title color contrast

### DIFF
--- a/assets/css/objects/step-common.css
+++ b/assets/css/objects/step-common.css
@@ -56,7 +56,7 @@
 /* Encabezados uniformes de los pasos */
 .step-title {
   align-items: center;
-  color: #d1d1d1;
+  color: #fff;
   display: flex;
   font-size: 1.5rem;
   font-weight: 800;


### PR DESCRIPTION
## Summary
- ensure step titles use white text

## Testing
- `phpunit`
- `npm run lint:css`
- `npm run build` *(fails: Unknown word `--bs-blue`)*

------
https://chatgpt.com/codex/tasks/task_e_68582dd9aa24832cad85486808a66824