### PR TITLE
Fix CSS reload issues on wizard step 6

### DIFF
--- a/assets/css/objects/wizard.css
+++ b/assets/css/objects/wizard.css
@@ -259,3 +259,6 @@ body{
     transition:transform .2s ease, filter .2s ease;
   }
 }
+
+.reset-wrap{ text-align:right; padding:.5rem 1rem; }
+

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -335,7 +335,7 @@ if (!file_exists($countUpLocal))   $assetErrors[] = 'CountUp.js faltante.';
                   <span class="slider-bubble"></span>
                 </div>
                 <div id="textPasadasInfo" class="small text-secondary mt-1">1 pasada de <?= number_format($thickness, 2) ?> mm</div>
-                <div id="errorMsg" class="text-danger mt-2 small" style="display:none"></div>
+                <div id="errorMsg" class="text-danger mt-2 small"></div>
               </div>
           </div>
         </div>
@@ -474,7 +474,13 @@ if (!file_exists($countUpLocal))   $assetErrors[] = 'CountUp.js faltante.';
 <script src="<?= file_exists($chartJsLocal) ? asset('node_modules/chart.js/dist/chart.umd.min.js') : 'https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js' ?>"></script>
 <script src="<?= file_exists($countUpLocal) ? asset('node_modules/countup.js/dist/countUp.umd.js') : 'https://cdn.jsdelivr.net/npm/countup.js/dist/countUp.umd.min.js' ?>"></script>
 <?php if ($step6JsRel): ?><script src="<?= $step6JsRel ?>"></script><?php endif; ?>
-<script>window.addEventListener('pageshow', e=>{if(e.persisted){location.reload();}});</script>
+<script>
+  window.addEventListener('pageshow', e => {
+    if (e.persisted && typeof window.initStep6 === 'function') {
+      window.initStep6();
+    }
+  });
+</script>
 <script>feather.replace();</script>
 
 <?php if (!$embedded): ?></div><!-- .container -->

--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -15,9 +15,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Wizard CNC</title>
-  <link rel="stylesheet" href="<?= asset('assets/css/components/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/objects/wizard.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/objects/stepper.css') ?>">
+  <link rel="stylesheet" href="<?= asset('assets/css/components/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/components/footer-schneider.css') ?>">
   <script>
     window.BASE_URL = <?= json_encode(BASE_URL) ?>;
@@ -44,7 +44,7 @@
   </header>
 
   <!-- Botón reset -->
-  <div style="text-align:right; padding:.5rem 1rem;">
+  <div class="reset-wrap">
     <a href="public/reset.php" class="btn btn-outline-light" onclick="localStorage.clear()">
       <i data-feather="refresh-ccw" class="me-1"></i>
       Volver al inicio


### PR DESCRIPTION
## Summary
- order stylesheets according to ITCSS in `wizard_layout.php`
- add a CSS rule for reset button wrapper and remove inline style
- remove inline `display:none` from step6 error message
- reload step6 scripts on `pageshow` instead of reloading the page

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685851779b54832cbceef300fd32ded2