### PR TITLE
Remove global flex centering from reset CSS

### DIFF
--- a/assets/css/generic/reset.css
+++ b/assets/css/generic/reset.css
@@ -16,16 +16,17 @@
 
 /* Estilo mínimo para cargar rápidamente */
 body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Segoe UI', Roboto, sans-serif;
+  color: #333;
+}
+
+body.center-screen {
   display: flex;
   align-items: center;
   justify-content: center;
-
   height: 100vh;
-  margin: 0;
-  padding: 0;
-
-  font-family: 'Segoe UI', Roboto, sans-serif;
-  color: #333;
 }
 
 .message-box {

--- a/public/reset.php
+++ b/public/reset.php
@@ -106,7 +106,7 @@ dbg('🔄 Nueva sesión limpia generada');
     const BASE_URL = <?= json_encode(BASE_URL) ?>;
   </script>
 </head>
-<body>
+<body class="center-screen">
   <div class="message-box">
     <h1>Reiniciando Wizard CNC...</h1>
     <p>Espere un instante...</p>


### PR DESCRIPTION
## Summary
- avoid vertical centering on all pages
- add `center-screen` helper class
- apply the class only to the reset page

## Testing
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_6858644202c0832c9f74c5f03b81d4b0