### PR TITLE
Fix step 6 layout

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -263,9 +263,10 @@ if (!file_exists($countUpLocal))   $assetErrors[] = 'CountUp.js faltante.';
   <?php endif; ?>
 </head>
 
+<?php if (!$embedded): ?>
 <body>
-<div class="container py-4">
 <?php endif; ?>
+<div class="container py-4">
 
 <?php if ($assetErrors): ?>
   <div class="alert alert-warning text-dark m-3"><strong>⚠️ Archivos faltantes (se usarán CDNs):</strong><ul><?php foreach ($assetErrors as $err): ?><li><?= htmlspecialchars($err, ENT_QUOTES) ?></li><?php endforeach; ?></ul></div>
@@ -488,6 +489,8 @@ if (!file_exists($countUpLocal))   $assetErrors[] = 'CountUp.js faltante.';
 </script>
 <script>feather.replace();</script>
 
-<?php if (!$embedded): ?></div><!-- .container -->
+</div><!-- .container -->
+<?php if (!$embedded): ?>
 </body>
-</html><?php endif; ?>
+</html>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- keep the container wrapper for step6 when embedded

## Testing
- `npm run lint:css`
- `npm run lint` *(fails: Missing script)*
- `vendor/bin/phpunit` *(fails: command not found)*
- `composer run-script lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586a3e1b2c832c8496dc245e364ff2