### PR TITLE
Fix container width on step6

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -264,8 +264,8 @@ if (!file_exists($countUpLocal))   $assetErrors[] = 'CountUp.js faltante.';
 </head>
 
 <body>
-<div class="container py-4">
 <?php endif; ?>
+<div class="container py-4">
 
 <?php if ($assetErrors): ?>
   <div class="alert alert-warning text-dark m-3"><strong>⚠️ Archivos faltantes (se usarán CDNs):</strong><ul><?php foreach ($assetErrors as $err): ?><li><?= htmlspecialchars($err, ENT_QUOTES) ?></li><?php endforeach; ?></ul></div>
@@ -488,6 +488,8 @@ if (!file_exists($countUpLocal))   $assetErrors[] = 'CountUp.js faltante.';
 </script>
 <script>feather.replace();</script>
 
-<?php if (!$embedded): ?></div><!-- .container -->
+</div><!-- .container -->
+<?php if (!$embedded): ?>
 </body>
-</html><?php endif; ?>
+</html>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- ensure step6 content always wrapped in container when embedded

## Testing
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68586a3e1b2c832c8496dc245e364ff2