### PR TITLE
Fix step 6 centering

### DIFF
--- a/assets/css/objects/wizard.css
+++ b/assets/css/objects/wizard.css
@@ -105,7 +105,7 @@ body{
 
   width:max-content;                       /* ancho = suma de hijos        */
   margin:0 auto;                           /* bloc centrado horizontal     */
-  padding:0;                               /* reset lista                  */
+  padding:0 14px;                          /* compensar tapas laterales    */
 
   list-style:none;                         /* sin bullets                  */
 


### PR DESCRIPTION
## Summary
- tweak `.stepper` padding to account for decorative caps

## Testing
- `npm run lint:css`
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858753e30f0832c90d2cbf3eaa028e0