### PR TITLE
Fix step 6 styling

### DIFF
--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -26,6 +26,9 @@
 <link rel="stylesheet" href="<?= asset('assets/css/objects/stepper.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/objects/step-common.css') ?>">
 
+  <!-- Bootstrap for step 6 -->
+  <link rel="stylesheet" href="<?= asset('assets/css/generic/bootstrap.min.css') ?>">
+
 <link rel="stylesheet" href="<?= asset('assets/css/components/components.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/components/main.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/components/footer-schneider.css') ?>">
@@ -81,6 +84,7 @@
   <?php endif; ?>
   <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
   <script>feather.replace();</script>
+  <script src="<?= asset('assets/js/bootstrap.bundle.min.js') ?>"></script>
   <script src="<?= asset('assets/js/wizard_stepper.js') ?>" defer></script>
   <script src="<?= asset('assets/js/dashboard.js') ?>" defer></script>
 


### PR DESCRIPTION
## Summary
- include Bootstrap CSS and JS in the global wizard layout so step 6 styles load properly

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68588823fe28832c851db543ca0d3b77