### PR TITLE
Fix missing CSS when loading step 6 directly

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -255,6 +255,7 @@ if (!file_exists($countUpLocal)) $assetErrors[] = 'CountUp.js faltante.';
     $styles = [
       $bootstrapCss,
       'assets/css/objects/step-common.css',
+      'assets/css/components/main.css',
       'assets/css/objects/step6.css',
     ];
     include __DIR__ . '/../partials/styles.php';


### PR DESCRIPTION
## Summary
- ensure standalone step6 page loads main.css

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588823fe28832c851db543ca0d3b77