### PR TITLE
Ensure step 6 cards are vertical

### DIFF
--- a/assets/css/components/_step6.css
+++ b/assets/css/components/_step6.css
@@ -64,10 +64,16 @@
 
 /* =========================  Grilla de tarjetas  ===================== */
 .cards-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  /*
+   * Display all step 6 cards stacked vertically. The previous grid
+   * layout placed cards side by side on wide screens. We switch to a
+   * flex column so each card occupies the full width of the container
+   * and appears one above the other.
+   */
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
-  align-items: flex-start;
+  align-items: stretch;
 }
 
 .cards-grid [class*="col-"] {flex: 0 0 auto !important;width: 100% !important;margin: 0 !important;}


### PR DESCRIPTION
## Summary
- stack step 6 cards vertically for clearer layout

## Testing
- `npm run lint:css`
- `composer test`
- `npm run build` *(fails: CssSyntaxError in bootstrap.min.css)*

------
https://chatgpt.com/codex/tasks/task_e_68588bb658bc832c926288b956f05cb0