### PR TITLE
Remove in-page debugging output

### DIFF
--- a/assets/js/step1_manual_table_hook.js
+++ b/assets/js/step1_manual_table_hook.js
@@ -6,8 +6,6 @@
  */
 export function dbg(...m) {
   console.log('[DBG]', ...m);
-  const box = document.getElementById('debug');
-  if (box) box.textContent += m.join(' ') + '\n';
 }
 
 export function initToolTable() {

--- a/assets/js/step1_manual_tool_browser.js
+++ b/assets/js/step1_manual_tool_browser.js
@@ -9,12 +9,12 @@
  * Navegador de herramientas con facetas, búsqueda y selección
  * ▸ 100 % compatible con el stepper (envía tool_id & tool_table)
  * ▸ Soporta acceso externo ?brand=&code=  (fallback GET → step 2)
- * ▸ Modo DEBUG: loguea TODO en consola + window.dbg()
+ * ▸ Modo DEBUG: loguea TODO en consola
  * ------------------------------------------------------------ */
 (() => {
   const BASE_URL = window.BASE_URL;
   /* -------- utilidades comunes ------------------------------------ */
-  const dbg = (...m) => {          // visible en consola + #debug
+  const dbg = (...m) => {          // visible en consola
     console.log('[STEP-1]', ...m);
     window.dbg?.('[STEP-1]', ...m);   // si existe helper global
   };

--- a/assets/js/step3_auto_lazy_loader.js
+++ b/assets/js/step3_auto_lazy_loader.js
@@ -14,8 +14,6 @@ const thickness = parseFloat(container.dataset.thickness || '0');
 
 window.dbg = function (...m) {
   console.log('[STEP3]', ...m);
-  const box = document.getElementById('debug');
-  if (box) box.textContent += m.join(' ') + '\n';
 };
 
 let page = 1;

--- a/assets/js/step7_expert_calculator.js
+++ b/assets/js/step7_expert_calculator.js
@@ -15,8 +15,6 @@ function initExpertResult(P) {
   if (!P || typeof P !== 'object') {
     const msg = '❌ Error: No se recibió el objeto de parámetros (P) o no es válido.';
     console.error(msg);
-    const dbg = document.getElementById('debug');
-    if (dbg) dbg.textContent = msg;
     return;
   }
 
@@ -25,8 +23,6 @@ function initExpertResult(P) {
   if (missing.length > 0) {
     const msg = '❌ Faltan datos en el objeto P: ' + missing.join(', ');
     console.error(msg);
-    const dbg = document.getElementById('debug');
-    if (dbg) dbg.textContent = msg;
     return;
   }
 
@@ -45,7 +41,6 @@ function initExpertResult(P) {
     vc_max_label: document.getElementById('vc_max_label'),
     material_thickness: document.getElementById('material_thickness'),
     ae_notice: document.getElementById('ae_notice'),
-    debug: document.getElementById('debug'),
     warning_feed: document.getElementById('warning-feed'),
     warning_rpm_low: document.getElementById('warning-rpm-low'),
     warning_rpm_high: document.getElementById('warning-rpm-high'),
@@ -58,7 +53,6 @@ function initExpertResult(P) {
   if (missingDom.length > 0) {
     const msg = '❌ Elementos del DOM faltantes: ' + missingDom.join(', ');
     console.error(msg);
-    if (domMap.debug) domMap.debug.textContent = msg;
     return;
   }
 
@@ -66,7 +60,7 @@ function initExpertResult(P) {
     fz_slider: fzS, vc_slider: vcS, ae_slider: aeS, pass_slider: passS,
     fz_value: fzV, vc_value: vcV, ae_value: aeV, pass_value: passV,
     fz_min_label: fzMinL, fz_max_label: fzMaxL, vc_min_label: vcMinL, vc_max_label: vcMaxL,
-    material_thickness: matThick, ae_notice: aeMsg, debug: dbg,
+    material_thickness: matThick, ae_notice: aeMsg,
     warning_feed: warnF, warning_rpm_low: warnL, warning_rpm_high: warnH,
     datos_extra: datosExtra
   } = domMap;
@@ -203,12 +197,12 @@ function initExpertResult(P) {
     if (warnL) warnL.style.display = rpm < P.rpmMin ? 'block' : 'none';
     if (warnH) warnH.style.display = rpm > P.rpmMax ? 'block' : 'none';
 
-    dbg.textContent = [
+    console.log([
       `MMR: ${mmr.toFixed(2)} mm³/min`,
       `RPM: ${Math.round(rpmClamped)}`,
       `Feed: ${Math.round(feed)} mm/min`,
       `Potencia: ${watts.toFixed(1)} W (${hp.toFixed(2)} HP)`
-    ].join('\n');
+    ].join('\n'));
 
     const extra = [
       `↕ ap (profundidad): ${ap.toFixed(2)} mm`,

--- a/assets/js/wizard_stepper.js
+++ b/assets/js/wizard_stepper.js
@@ -21,11 +21,10 @@
     if (!DEBUG) return fn();
     console.group(title); try { fn(); } finally { console.groupEnd(); }
   };
-  const dbgBox = $qs('#debug');
   const dbgMsg = txt => {
-    if (!dbgBox) return;
+    if (!DEBUG) return;
     const ts = new Date().toLocaleTimeString();
-    dbgBox.textContent = `[${ts}] ${txt}\n` + dbgBox.textContent;
+    console.log(`[${ts}] ${txt}`);
   };
 
   const stepsBar   = $qsa('.stepper li');

--- a/includes/debug.php
+++ b/includes/debug.php
@@ -8,7 +8,7 @@
  */
 /**
  * Helper ultra-liviano de depuración.
- *  – dbg('texto', $array) → console.log + <pre id="debug"> (si existe)
+ *  – dbg('texto', $array) → error_log('[DBG] ...')
  */
 
 if (!function_exists('dbg')) {
@@ -18,25 +18,6 @@ if (!function_exists('dbg')) {
         foreach ($msg as $m) {
             $line[] = is_scalar($m) ? $m : json_encode($m, JSON_UNESCAPED_UNICODE);
         }
-        $text = '[DBG] '.implode(' ', $line);
-        $safeJs = json_encode($text);
-
-        // A) consola JS
-        echo "<script>console.log($safeJs);</script>";
-
-        // B) caja <pre id="debug"> (si está en el DOM)
-        static $once = false;
-        if (!$once) {
-            echo <<<TAG
-<script>
-window.__DBG = t => {
-  const box = document.getElementById('debug');
-  if (box) box.textContent = t + '\\n' + box.textContent;
-};
-</script>
-TAG;
-            $once = true;
-        }
-        echo "<script>window.__DBG($safeJs);</script>";
+        error_log('[DBG] ' . implode(' ', $line));
     }
 }

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -293,8 +293,6 @@ dbg('children', $children);
     </div>
   </form>
 
-  <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>
-
   <script>
   //────────────────────────────────────────────────────────────────────
   // normalizeText: Quita tildes, pasa a minúsculas

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -264,8 +264,6 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
     </div>
   </form>
 
-  <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>
-
   <script>
   (function() {
     // Datos PHP → JS

--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -210,7 +210,6 @@ try {
   <!-- Botón "Siguiente" removido -->
 
   <!-- 7.4) Consola interna de debugging -->
-  <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>
 
   <!-- Bootstrap JS (para estilos, no es estrictamente necesario) -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
@@ -218,11 +217,9 @@ try {
   <!-- 7.5) Script inline con toda la lógica AJAX + render + filtrado -->
   <script>
   (() => {
-    // Helper de debug: imprime en consola y en <pre id="debug">
+    // Helper de debug: imprime únicamente en la consola
     window.dbg = (...msgs) => {
       console.log('[STEP-3]', ...msgs);
-      const box = document.getElementById('debug');
-      if (box) box.textContent += msgs.join(' ') + '\n';
     };
 
     dbg('ℹ [step3.js] Iniciando lógica de Paso 3 (Auto)');

--- a/views/steps/auto/step3_auto_lazy_browser.php
+++ b/views/steps/auto/step3_auto_lazy_browser.php
@@ -54,7 +54,6 @@ $thickness  = $_SESSION['thickness']  ?? null;
          data-thickness="<?= htmlspecialchars((string)$thickness) ?>">
     </div>
     <div id="scrollSentinel"></div>
-    <pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>
   </main>
   <script type="module" src="<?= asset('assets/js/step3_auto_lazy_loader.js') ?>"></script>
 </body>

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -211,7 +211,5 @@ if($tool){
   <?php endif; ?>
 </div>
 
-<!-- Consola interna -->
-<pre id="debug" class="debug-box"></pre>
 </body>
 </html>

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -245,9 +245,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </main>
   </form>
 
-  <!-- Caja opcional de debugging -->
-  <pre id="debug" class="debug-box"></pre>
-
   <!-- ─────────────── Scripts ──────────────────────────────────────── -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -12,7 +12,7 @@
  *   persistidos en $_SESSION (fallback).
  * - Agrega campo oculto step=2 para que el Stepper no marque
  *   “Paso inválido”.
- * - Funciones dbg() imprimen todo en la consola y en <pre id="debug">.
+ * - Funciones dbg() registran información en el log de errores.
  */
 declare(strict_types=1);
 require_once __DIR__ . '/../../../includes/db.php';
@@ -22,11 +22,7 @@ if (!function_exists('dbg')) {
     function dbg(string $tag, $data = null): void {
         $txt = '['.date('H:i:s')."] {$tag} "
              . (is_scalar($data) ? $data : json_encode($data, JSON_UNESCAPED_UNICODE));
-        echo "<script>console.log(".json_encode($txt).");</script>";
-        echo "<script>
-                (t => {const d=document.getElementById('debug');
-                       if(d){d.textContent+=t+'\\n';}})(".json_encode($txt).");
-              </script>";
+        error_log($txt);
     }
 }
 
@@ -201,8 +197,6 @@ if ($tool) {
   <?php endif; ?>
 </div>
 
-<!-- consola interna -->
-<pre id="debug" class="debug-box"></pre>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -256,7 +256,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   </form>
   <?php endif; ?>
 
-  <pre id="debug" class="debug-box"></pre>
 </main>
 
 <!-- Bootstrap Bundle -->

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -213,7 +213,6 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
   </div>
 </form>
 
-<pre id="debug" class="bg-dark text-info p-2 mt-4"></pre>
 </main>
 
 <script>

--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -73,9 +73,6 @@
   <!-- Dashboard (opcional) -->
   <section id="wizard-dashboard"></section>
 
-  <!-- Consola interna -->
-  <pre id="debug" class="debug-box"></pre>
-
   <!-- Scripts -->
   <?php if (!empty($_SESSION['csrf_token'])): ?>
   <script>


### PR DESCRIPTION
## Summary
- log debug messages to PHP's error log
- drop DOM log targets from JS modules
- remove `<pre id="debug">` containers from templates

## Testing
- `npx --yes stylelint "assets/css/**/*.css"` *(fails: Could not find stylelint-config-standard)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68588f3ac01c832cae4ff4fe7e7fef89