### PR TITLE
Fix step6 style imports

### DIFF
--- a/assets/css/objects/step6.css
+++ b/assets/css/objects/step6.css
@@ -1,7 +1,3 @@
-@import url('../settings/_variables.css');
-@import url('../generic/reset.css');
-@import url('../elements/_typography.css');
-
 .step6-error {
   padding: 1rem;
   color: #fff;


### PR DESCRIPTION
## Summary
- streamline `step6.css` by removing redundant `@import` lines

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68588f012ffc832c8a273060dc3d36e6