### PR TITLE
Fix double load of step6.js

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -636,7 +636,9 @@ if (!file_exists($countUpLocal)) $assetErrors[] = 'CountUp.js faltante.';
 <script src="<?= file_exists($countUpLocal)
   ? asset('node_modules/countup.js/dist/countUp.umd.js')
   : 'https://cdn.jsdelivr.net/npm/countup.js/dist/countUp.umd.min.js' ?>"></script>
-<?php if ($step6JsRel): ?><script src="<?= $step6JsRel ?>"></script><?php endif; ?>
+<?php if (!$embedded && $step6JsRel): ?>
+  <script src="<?= $step6JsRel ?>"></script>
+<?php endif; ?>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     if (typeof window.initStep6 === 'function') initStep6();


### PR DESCRIPTION
## Summary
- avoid loading step6.js twice when the view is embedded

## Testing
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68588f012ffc832c8a273060dc3d36e6