### PR TITLE
Adjust manual step image sizing and button text

### DIFF
--- a/assets/css/components/_step1.css
+++ b/assets/css/components/_step1.css
@@ -72,8 +72,8 @@
 }
 
 .thumb {               /* Miniaturas de marcas */
-  width: 40px;
-  height: 40px;
+  width: 80px;        /* ancho ampliado */
+  height: 80px;       /* mantiene proporción */
   border: 1px solid #ddd;
   object-fit: contain; /* evita distorsión de la imagen */
 }

--- a/assets/js/step1_manual_tool_browser.js
+++ b/assets/js/step1_manual_tool_browser.js
@@ -128,10 +128,11 @@
   function renderTable(){
     tableBody.innerHTML='';
     toolsData.forEach(t=>{
-      tableBody.insertAdjacentHTML('beforeend',`
+        tableBody.insertAdjacentHTML('beforeend',`
         <tr>
           <td><button class="btn btn-sm btn-primary select-btn"
-                 data-tool_id="${t.tool_id}" data-tbl="${t.tbl}">✓</button></td>
+                 data-tool_id="${t.tool_id}" data-tbl="${t.tbl}">
+                 Seleccionar <i class="bi bi-arrow-right"></i></button></td>
           <td><span class="badge bg-info text-dark">${t.brand}</span></td>
           <td>${t.series_code}</td>
           <td>${t.details.image?`<img src="${BASE_URL}/${t.details.image}" class="thumb">`:''}</td>


### PR DESCRIPTION
## Summary
- enlarge tool thumbnails in manual mode
- show "Seleccionar" button with arrow

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589b4e8f78832c9bc92a8adb8d6f00