### PR TITLE
Remove leftover mobile CSS in step 6

### DIFF
--- a/assets/css/components/_step6.css
+++ b/assets/css/components/_step6.css
@@ -164,22 +164,16 @@ body.debug-mode .card {outline: 1px dashed magenta;}
 .debug-panel.show {display: block;}
 
 /* ==========================  Mobile tweaks  ======================== */
+/*
+ * Mobile tweaks
+ * La versión actual del Paso 6 ya no utiliza un contenedor
+ * fijo para los sliders, por lo que este bloque generaba un
+ * margen inferior excesivo y estilos huérfanos. Se elimina
+ * el layout fijo y el margen extra para evitar distorsiones
+ * en pantallas pequeñas.
+ */
 @media (width <= 991px) {
-  .content-main {margin-bottom: 12rem;}
-
-  .slider-box {
-    position: fixed;
-    z-index: 1040;
-    bottom: 0; left: 0;
-
-    overflow-y: auto;
-
-    width: 100%;
-    max-height: 50%;
-    padding: 0.5rem;
-
-    background: var(--bg-card);
-  }
+  /* Sin margen adicional ni slider-box flotante */
 }
 
 /* Indicador de cabezales colapsables (sin interferir con stepper) */


### PR DESCRIPTION
## Summary
- clean up mobile rules in `_step6.css`

## Testing
- `composer test` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68589dfb7878832cb16bb18ad92a5d2a