### PR TITLE
Ensure step6.js only loads once

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -642,7 +642,9 @@ if (!file_exists($countUpLocal)) $assetErrors[] = 'CountUp.js faltante.';
 <script src="<?= asset('node_modules/feather-icons/dist/feather.min.js') ?>"></script>
 <script src="<?= asset('node_modules/chart.js/dist/chart.umd.min.js') ?>"></script>
 <script src="<?= asset('node_modules/countup.js/dist/countUp.umd.js') ?>"></script>
+<?php if (!$embedded): ?>
 <script src="<?= $step6JsRel ?>"></script>
+<?php endif; ?>
 <script>feather.replace();</script>
 
 <?php if (!$embedded): ?>


### PR DESCRIPTION
## Summary
- load `step6.js` only when wizard isn't embedded

## Testing
- `composer test` *(fails: composer not installed)*
- `./vendor/bin/phpunit` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858a871e1e4832c9492e513ba41c68d