### PR TITLE
Fix Step 6 CSS in wizard layout

### DIFF
--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -25,6 +25,8 @@
 <link rel="stylesheet" href="<?= asset('assets/css/objects/wizard.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/objects/stepper.css') ?>">
 <link rel="stylesheet" href="<?= asset('assets/css/objects/step-common.css') ?>">
+  <!-- Estilos específicos del paso 6 -->
+  <link rel="stylesheet" href="<?= asset('assets/css/objects/step6.css') ?>">
 
   <!-- Bootstrap for step 6 -->
   <link rel="stylesheet" href="<?= asset('assets/css/generic/bootstrap.min.css') ?>">


### PR DESCRIPTION
## Summary
- ensure Step 6 stylesheet loads when step is embedded

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a96c476c832c84449db2c703d32c