### PR TITLE
Refactor paso 6 y assets

### DIFF
--- a/ajax/step6_ajax_legacy_minimal.php
+++ b/ajax/step6_ajax_legacy_minimal.php
@@ -1,13 +1,18 @@
 <?php
 /**
  * File: step6_ajax_legacy_minimal.php
+ * ------------------------------------------------------------------
+ * Endpoint AJAX para el Paso 6.
  *
- * Main responsibility: Part of the CNC Wizard Stepper.
- *
- * Called by: assets/js/step6.js to compute machining parameters
- * Important JSON fields: fz, vc, ae, passes, thickness, D, Z, params[*]
- * Uses session key: $_SESSION['csrf_token'] for validation
- * @TODO Extend documentation.
+ * Entrada JSON esperada:
+ *   {
+ *     fz:number, vc:number, ae:number, passes:int,
+ *     thickness:number, D:number, Z:int,
+ *     params:{ fr_max:number, coef_seg:number, Kc11:number,
+ *              mc:number, alpha:number, eta:number }
+ *   }
+ * Devuelve: { success:bool, data:{...}, error?:string }
+ * El token CSRF debe enviarse en la cabecera "X-CSRF-Token".
  */
 /**
  * Ubicación: C:\xampp\htdocs\wizard-stepper_git\ajax\step6_ajax_legacy_minimal.php
@@ -25,13 +30,15 @@ if (!getenv('BASE_URL')) {
     putenv('BASE_URL=' . $base);
 }
 require_once __DIR__ . '/../src/Config/AppConfig.php';
+require_once __DIR__ . '/../src/Utils/Session.php';
 
 // Cabeceras JSON
 header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 
 // Iniciar sesión para CSRF
-session_start(); // ensures $_SESSION['csrf_token'] is available
+startSecureSession();
+generateCsrfToken();
 
 // 0. CSRF: validar token enviado en header X-CSRF-Token
 $token = (string)($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');

--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -26,8 +26,12 @@ window.initStep6 = function () {
     flute_count: Z,
     rpm_min: rpmMin,
     rpm_max: rpmMax,
-    fr_max,
-    coef_seg, Kc11, mc, alpha, eta,
+    fr_max = Number.POSITIVE_INFINITY,
+    coef_seg = 1,
+    Kc11 = 1200,
+    mc = 0.2,
+    alpha = 0,
+    eta = 1,
   } = window.step6Params || {};
 
   const csrfToken = window.step6Csrf;
@@ -127,12 +131,16 @@ window.initStep6 = function () {
 
   // 7. Bloqueo de slider
   function lockSlider(slider, msg) {
+    if (!slider.dataset.limitValue) {
+      slider.dataset.limitValue = slider.value;
+    }
     slider.value = slider.dataset.limitValue;
     slider.disabled = true;
     showError(msg);
   }
   function unlockSlider(slider) {
     slider.disabled = false;
+    delete slider.dataset.limitValue;
   }
 
   // 8. Pasadas slider / info

--- a/views/partials/styles.php
+++ b/views/partials/styles.php
@@ -3,17 +3,35 @@
  * Render <link> tags for CSS styles.
  *
  * Variables expected:
- *   - array $styles    List of relative paths or absolute URLs
- *   - bool  $embedded  If true, main.css will not be included
+ *   - array $styles      List of relative paths or absolute URLs
+ *   - bool  $embedded    If true, body background is transparent
+ *   - array $assetErrors (optional) collects missing local assets
  */
-$embedded = $embedded ?? (defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED);
-$styles = $styles ?? [];
-// main.css is now loaded globally from wizard_layout.php
+
+$embedded    = $embedded ?? (defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED);
+$styles      = $styles ?? [];
+$assetErrors = $assetErrors ?? [];
+$root        = dirname(__DIR__, 2) . '/';
+
 foreach ($styles as $href) {
-    $url = str_starts_with($href, 'http') ? $href : asset($href);
-    echo '<link rel="stylesheet" href="'.$url.'">'.PHP_EOL;
+    if (str_starts_with($href, 'http')) {
+        $url = $href;
+    } else {
+        $file = $root . ltrim($href, '/');
+        if (!is_file($file)) {
+            $assetErrors[] = basename($href) . ' no encontrado localmente.';
+            if ($href === 'assets/css/generic/bootstrap.min.css') {
+                $url = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css';
+            } else {
+                $url = asset($href);
+            }
+        } else {
+            $url = asset($href);
+        }
+    }
+    echo '<link rel="stylesheet" href="' . $url . '">' . PHP_EOL;
 }
 if ($embedded) {
-    echo '<style>body{background-color:transparent!important;}</style>'.PHP_EOL;
+    echo '<style>body{background-color:transparent!important;}</style>' . PHP_EOL;
 }
 ?>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -1,8 +1,15 @@
 <?php
 /**
  * File: views/steps/step6.php
- * Descripción: Paso 6 – Resultados expertos del Wizard CNC
- * Versión pulida: se corrigieron nombres de IDs, clases CSS, chequeos de constantes y algunas advertencias PHP.
+ * ---------------------------------------------------------------------
+ * Paso 6 – Resultados expertos del Wizard CNC.
+ *
+ * Entradas  : valores en $_SESSION establecidos por los pasos previos.
+ *             En POST se espera 'csrf_token' para validación manual.
+ * Salidas   : HTML completo o fragmento (si WIZARD_EMBEDDED).
+ *
+ * Flujo CSRF: el token se genera al iniciar sesión y se valida únicamente
+ *             para peticiones POST (form o AJAX).
  */
 
 declare(strict_types=1);
@@ -17,12 +24,9 @@ if (!getenv('BASE_URL')) {
     );
 }
 require_once __DIR__ . '/../../src/Config/AppConfig.php';
+require_once __DIR__ . '/../../src/Utils/Session.php';
 
 use App\Controller\ExpertResultController;
-
-// ────────────────────────────────────────────────────────────────
-// Utilidades / helpers
-// ────────────────────────────────────────────────────────────────
 
 require_once __DIR__ . '/../../includes/wizard_helpers.php';
 
@@ -31,35 +35,37 @@ require_once __DIR__ . '/../../includes/wizard_helpers.php';
 // ────────────────────────────────────────────────────────────────
 $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
 
-if (!$embedded) {
-    /* Cabeceras de seguridad */
-    header('Content-Type: text/html; charset=UTF-8');
-    header('Strict-Transport-Security: max-age=31536000; includeSubDomains; preload');
-    header('X-Frame-Options: DENY');
-    header('X-Content-Type-Options: nosniff');
-    header('Referrer-Policy: no-referrer');
-    header("Permissions-Policy: geolocation=(), microphone=()");
-    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
-    header('Pragma: no-cache');
-    header(
-        "Content-Security-Policy: default-src 'self';"
-        . " script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;"
-        . " style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;"
-    );
-}
-
 // ────────────────────────────────────────────────────────────────
 // Sesión segura
 // ────────────────────────────────────────────────────────────────
-if (session_status() !== PHP_SESSION_ACTIVE) {
-    session_set_cookie_params([
-        'lifetime' => 0,
-        'path'     => '/',
-        'secure'   => true,
-        'httponly' => true,
-        'samesite' => 'Strict'
-    ]);
-    session_start();
+startSecureSession();
+$csrfToken = generateCsrfToken();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !validateCsrfToken($_POST['csrf_token'] ?? null)) {
+    http_response_code(403);
+    exit('Error CSRF: petición no autorizada.');
+}
+
+// ────────────────────────────────────────────────────────────────
+// Validar claves requeridas antes de cargar modelos o DB
+// ────────────────────────────────────────────────────────────────
+$requiredKeys = [
+    'tool_table','tool_id','material','trans_id',
+    'rpm_min','rpm_max','fr_max','thickness',
+    'strategy','hp'
+];
+$missing = array_filter($requiredKeys, fn($k) => empty($_SESSION[$k]));
+if ($missing) {
+    http_response_code(400);
+    echo "<pre class='step6-error'>ERROR – faltan claves en sesión:\n" . implode(', ', $missing) . "</pre>";
+    exit;
+}
+
+if (!$embedded) {
+    sendSecurityHeaders('text/html; charset=UTF-8');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;");
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -92,34 +98,6 @@ $_SESSION['trans_id'] = $_SESSION['transmission_id'] ?? ($_SESSION['trans_id']  
 $_SESSION['fr_max']   = $_SESSION['feed_max']        ?? ($_SESSION['fr_max']     ?? null);
 $_SESSION['strategy'] = $_SESSION['strategy_id']     ?? ($_SESSION['strategy']   ?? null);
 
-// ────────────────────────────────────────────────────────────────
-// CSRF token
-// ────────────────────────────────────────────────────────────────
-if (empty($_SESSION['csrf_token'])) {
-    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
-}
-$csrfToken = $_SESSION['csrf_token'];
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (!hash_equals($csrfToken, (string)($_POST['csrf_token'] ?? ''))) {
-        http_response_code(403);
-        exit('Error CSRF: petición no autorizada.');
-    }
-}
-
-// ────────────────────────────────────────────────────────────────
-// Validar claves requeridas
-// ────────────────────────────────────────────────────────────────
-$requiredKeys = [
-    'tool_table','tool_id','material','trans_id',
-    'rpm_min','rpm_max','fr_max','thickness',
-    'strategy','hp'
-];
-$missing = array_filter($requiredKeys, fn($k) => empty($_SESSION[$k]));
-if ($missing) {
-    http_response_code(400);
-    echo "<pre class='step6-error'>ERROR – faltan claves en sesión:\n" . implode(', ', $missing) . "</pre>";
-    exit;
-}
 
 // ────────────────────────────────────────────────────────────────
 // Cargar modelos y utilidades
@@ -218,22 +196,33 @@ $notesArray = $params['notes'] ?? [];
 // ────────────────────────────────────────────────────────────────
 // Assets locales / CDN fall-back
 // ────────────────────────────────────────────────────────────────
-$cssBootstrapRel = file_exists($root.'assets/css/generic/bootstrap.min.css')
-    ? asset('assets/css/generic/bootstrap.min.css')
-    : '';
-$bootstrapJsRel  = file_exists($root.'assets/js/bootstrap.bundle.min.js')
+$styles = [
+    'assets/css/generic/bootstrap.min.css',
+    'assets/css/settings/settings.css',
+    'assets/css/generic/generic.css',
+    'assets/css/elements/elements.css',
+    'assets/css/objects/objects.css',
+    'assets/css/objects/wizard.css',
+    'assets/css/objects/stepper.css',
+    'assets/css/objects/step-common.css',
+    'assets/css/objects/step6.css',
+    'assets/css/components/components.css',
+    'assets/css/components/main.css',
+    'assets/css/components/footer-schneider.css',
+    'assets/css/utilities/utilities.css',
+];
+
+$bootstrapJsRel = file_exists($root.'assets/js/bootstrap.bundle.min.js')
     ? asset('assets/js/bootstrap.bundle.min.js')
-    : '';
+    : 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js';
 $featherLocal    = $root.'node_modules/feather-icons/dist/feather.min.js';
 $chartJsLocal    = $root.'node_modules/chart.js/dist/chart.umd.min.js';
 $countUpLocal    = $root.'node_modules/countup.js/dist/countUp.umd.js';
-$step6JsRel      = file_exists($root.'assets/js/step6.js')
-    ? asset('assets/js/step6.js')
-    : '';
+$step6JsRel      = file_exists($root.'assets/js/step6.js') ? asset('assets/js/step6.js') : '';
 
 $assetErrors = [];
-if (!$cssBootstrapRel)           $assetErrors[] = 'Bootstrap CSS no encontrado localmente.';
-if (!$bootstrapJsRel)            $assetErrors[] = 'Bootstrap JS no encontrado localmente.';
+if (!file_exists($root.'assets/js/bootstrap.bundle.min.js'))
+    $assetErrors[] = 'Bootstrap JS no encontrado localmente.';
 if (!file_exists($featherLocal)) $assetErrors[] = 'Feather Icons JS faltante.';
 if (!file_exists($chartJsLocal)) $assetErrors[] = 'Chart.js faltante.';
 if (!file_exists($countUpLocal)) $assetErrors[] = 'CountUp.js faltante.';
@@ -249,32 +238,13 @@ if (!file_exists($countUpLocal)) $assetErrors[] = 'CountUp.js faltante.';
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Cutting Data – Paso&nbsp;6</title>
-  <?php
-    $bootstrapCss = $cssBootstrapRel
-      ?: 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css';
-    $styles = [
-      $bootstrapCss,
-      'assets/css/settings/settings.css',
-      'assets/css/generic/generic.css',
-      'assets/css/elements/elements.css',
-      'assets/css/objects/objects.css',
-      'assets/css/objects/wizard.css',
-      'assets/css/objects/stepper.css',
-      'assets/css/objects/step-common.css',
-      'assets/css/objects/step6.css',
-      'assets/css/components/components.css',
-      'assets/css/components/main.css',
-      'assets/css/components/footer-schneider.css',
-      'assets/css/utilities/utilities.css',
-    ];
-    include __DIR__ . '/../partials/styles.php';
-  ?>
-  <?php if (!$embedded): ?>
-    <script>
-      window.BASE_URL  = <?= json_encode(BASE_URL) ?>;
-      window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
-    </script>
-  <?php endif; ?>
+<?php endif; ?>
+<?php include __DIR__ . '/../partials/styles.php'; ?>
+<?php if (!$embedded): ?>
+  <script>
+    window.BASE_URL  = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- centralize CSS handling in `partials/styles.php`
- normalize session & CSRF handling in step6 view
- output full page only when not embedded
- add defaults & slider fixes in `step6.js`
- document AJAX endpoint and use secure session

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `npm run build` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858af8564c0832c8718ace8c6ca5691