### PR TITLE
Simplify step6 embedding and asset handling

### DIFF
--- a/ajax/step6_ajax_legacy_minimal.php
+++ b/ajax/step6_ajax_legacy_minimal.php
@@ -4,9 +4,14 @@
  *
  * Main responsibility: Part of the CNC Wizard Stepper.
  *
- * Called by: assets/js/step6.js to compute machining parameters
- * Important JSON fields: fz, vc, ae, passes, thickness, D, Z, params[*]
- * Uses session key: $_SESSION['csrf_token'] for validation
+ * Endpoint llamado por assets/js/step6.js para recalcular parámetros.
+ *
+ * Entradas JSON (POST):
+ *   - fz, vc, ae, passes, thickness, D, Z
+ *   - params{ fr_max, coef_seg, Kc11, mc, alpha, eta, ... }
+ * Salida JSON:
+ *   { success: bool, data: {...}, error?: string }
+ * Requiere token CSRF vía header X-CSRF-Token y usa $_SESSION['csrf_token'].
  * @TODO Extend documentation.
  */
 /**

--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -22,12 +22,16 @@ window.initStep6 = function () {
   const group = (title, fn) => { if (!DEBUG) return fn(); console.group(`${TAG} ${new Date().toISOString()} ${title}`); try { return fn(); } finally { console.groupEnd(); } };
   // 1. Parámetros inyectados por PHP
   const {
-    diameter: D,
-    flute_count: Z,
-    rpm_min: rpmMin,
-    rpm_max: rpmMax,
-    fr_max,
-    coef_seg, Kc11, mc, alpha, eta,
+    diameter: D = 0,
+    flute_count: Z = 1,
+    rpm_min: rpmMin = 0,
+    rpm_max: rpmMax = 0,
+    fr_max = Infinity,
+    coef_seg = 0,
+    Kc11 = 1,
+    mc = 1,
+    alpha = 0,
+    eta = 1,
   } = window.step6Params || {};
 
   const csrfToken = window.step6Csrf;
@@ -127,12 +131,14 @@ window.initStep6 = function () {
 
   // 7. Bloqueo de slider
   function lockSlider(slider, msg) {
-    slider.value = slider.dataset.limitValue;
+    if (!slider.dataset.prevValue) slider.dataset.prevValue = slider.value;
+    slider.value = slider.dataset.prevValue;
     slider.disabled = true;
     showError(msg);
   }
   function unlockSlider(slider) {
     slider.disabled = false;
+    slider.dataset.prevValue = '';
   }
 
   // 8. Pasadas slider / info
@@ -165,12 +171,10 @@ window.initStep6 = function () {
           feed = computeFeed(vc, fz);
 
     if (feed > fr_max) {
-      this.dataset.limitValue = this.value;
       lockSlider(this, `Feedrate supera límite (${fr_max}). Ajusta el otro valor.`);
       return;
     }
     if (feed <= 0) {
-      this.dataset.limitValue = this.value;
       lockSlider(this, `Feedrate demasiado bajo.`);
       return;
     }

--- a/views/partials/styles.php
+++ b/views/partials/styles.php
@@ -3,14 +3,23 @@
  * Render <link> tags for CSS styles.
  *
  * Variables expected:
- *   - array $styles    List of relative paths or absolute URLs
- *   - bool  $embedded  If true, main.css will not be included
+ *   - array $styles       List of relative paths or absolute URLs
+ *   - bool  $embedded     If true, main.css will not be included
+ *   - array &$assetErrors Optional array where missing local files are noted
  */
-$embedded = $embedded ?? (defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED);
-$styles = $styles ?? [];
+$embedded    = $embedded ?? (defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED);
+$styles      = $styles ?? [];
+$assetErrors = $assetErrors ?? [];
 // main.css is now loaded globally from wizard_layout.php
 foreach ($styles as $href) {
-    $url = str_starts_with($href, 'http') ? $href : asset($href);
+    $isUrl = str_starts_with($href, 'http');
+    $url   = $isUrl ? $href : asset($href);
+    if (!$isUrl) {
+        $file = dirname(__DIR__, 2) . '/' . ltrim($href, '/');
+        if (!is_readable($file)) {
+            $assetErrors[] = basename($href) . ' no encontrado localmente.';
+        }
+    }
     echo '<link rel="stylesheet" href="'.$url.'">'.PHP_EOL;
 }
 if ($embedded) {

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -3,6 +3,13 @@
  * File: views/steps/step6.php
  * Descripción: Paso 6 – Resultados expertos del Wizard CNC
  * Versión pulida: se corrigieron nombres de IDs, clases CSS, chequeos de constantes y algunas advertencias PHP.
+ *
+ * Entradas:
+ *   - GET  "debug"  para activar modo detallado
+ *   - POST "csrf_token" sólo cuando se envía el formulario local
+ * Salidas:
+ *   - HTML completo o fragmento embebible según $embedded
+ *   - window.step6Params y window.step6Csrf para el JS
  */
 
 declare(strict_types=1);
@@ -31,6 +38,20 @@ require_once __DIR__ . '/../../includes/wizard_helpers.php';
 // ────────────────────────────────────────────────────────────────
 $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
 
+// ────────────────────────────────────────────────────────────────
+// Sesión segura (siempre antes de imprimir cabeceras)
+// ────────────────────────────────────────────────────────────────
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_set_cookie_params([
+        'lifetime' => 0,
+        'path'     => '/',
+        'secure'   => true,
+        'httponly' => true,
+        'samesite' => 'Strict'
+    ]);
+    session_start();
+}
+
 if (!$embedded) {
     /* Cabeceras de seguridad */
     header('Content-Type: text/html; charset=UTF-8');
@@ -49,39 +70,11 @@ if (!$embedded) {
 }
 
 // ────────────────────────────────────────────────────────────────
-// Sesión segura
-// ────────────────────────────────────────────────────────────────
-if (session_status() !== PHP_SESSION_ACTIVE) {
-    session_set_cookie_params([
-        'lifetime' => 0,
-        'path'     => '/',
-        'secure'   => true,
-        'httponly' => true,
-        'samesite' => 'Strict'
-    ]);
-    session_start();
-}
-
-// ────────────────────────────────────────────────────────────────
 // Debug opcional
 // ────────────────────────────────────────────────────────────────
 $DEBUG = filter_input(INPUT_GET, 'debug', FILTER_VALIDATE_BOOLEAN);
 if ($DEBUG && is_readable(__DIR__ . '/../../includes/debug.php')) {
     require_once __DIR__ . '/../../includes/debug.php';
-}
-
-// ────────────────────────────────────────────────────────────────
-// Conexión BD
-// ────────────────────────────────────────────────────────────────
-$dbFile = __DIR__ . '/../../includes/db.php';
-if (!is_readable($dbFile)) {
-    http_response_code(500);
-    exit('Error interno: falta el archivo de conexión a la BD.');
-}
-require_once $dbFile;           //-> $pdo
-if (!isset($pdo) || !($pdo instanceof PDO)) {
-    http_response_code(500);
-    exit('Error interno: no hay conexión a la base de datos.');
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -119,6 +112,20 @@ if ($missing) {
     http_response_code(400);
     echo "<pre class='step6-error'>ERROR – faltan claves en sesión:\n" . implode(', ', $missing) . "</pre>";
     exit;
+}
+
+// ────────────────────────────────────────────────────────────────
+// Conexión BD
+// ────────────────────────────────────────────────────────────────
+$dbFile = __DIR__ . '/../../includes/db.php';
+if (!is_readable($dbFile)) {
+    http_response_code(500);
+    exit('Error interno: falta el archivo de conexión a la BD.');
+}
+require_once $dbFile;           //-> $pdo
+if (!isset($pdo) || !($pdo instanceof PDO)) {
+    http_response_code(500);
+    exit('Error interno: no hay conexión a la base de datos.');
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -216,27 +223,26 @@ try {
 $notesArray = $params['notes'] ?? [];
 
 // ────────────────────────────────────────────────────────────────
-// Assets locales / CDN fall-back
+// Assets locales
 // ────────────────────────────────────────────────────────────────
-$cssBootstrapRel = file_exists($root.'assets/css/generic/bootstrap.min.css')
-    ? asset('assets/css/generic/bootstrap.min.css')
-    : '';
-$bootstrapJsRel  = file_exists($root.'assets/js/bootstrap.bundle.min.js')
-    ? asset('assets/js/bootstrap.bundle.min.js')
-    : '';
+$cssBootstrapRel = asset('assets/css/generic/bootstrap.min.css');
+$bootstrapJsRel  = asset('assets/js/bootstrap.bundle.min.js');
 $featherLocal    = $root.'node_modules/feather-icons/dist/feather.min.js';
 $chartJsLocal    = $root.'node_modules/chart.js/dist/chart.umd.min.js';
 $countUpLocal    = $root.'node_modules/countup.js/dist/countUp.umd.js';
-$step6JsRel      = file_exists($root.'assets/js/step6.js')
-    ? asset('assets/js/step6.js')
-    : '';
+$step6JsRel      = asset('assets/js/step6.js');
 
 $assetErrors = [];
-if (!$cssBootstrapRel)           $assetErrors[] = 'Bootstrap CSS no encontrado localmente.';
-if (!$bootstrapJsRel)            $assetErrors[] = 'Bootstrap JS no encontrado localmente.';
-if (!file_exists($featherLocal)) $assetErrors[] = 'Feather Icons JS faltante.';
-if (!file_exists($chartJsLocal)) $assetErrors[] = 'Chart.js faltante.';
-if (!file_exists($countUpLocal)) $assetErrors[] = 'CountUp.js faltante.';
+if (!is_readable($root.'assets/css/generic/bootstrap.min.css'))
+    $assetErrors[] = 'Bootstrap CSS no encontrado localmente.';
+if (!is_readable($root.'assets/js/bootstrap.bundle.min.js'))
+    $assetErrors[] = 'Bootstrap JS no encontrado localmente.';
+if (!file_exists($featherLocal))
+    $assetErrors[] = 'Feather Icons JS faltante.';
+if (!file_exists($chartJsLocal))
+    $assetErrors[] = 'Chart.js faltante.';
+if (!file_exists($countUpLocal))
+    $assetErrors[] = 'CountUp.js faltante.';
 
 // =====================================================================
 // =========================  COMIENZA SALIDA  ==========================
@@ -250,10 +256,8 @@ if (!file_exists($countUpLocal)) $assetErrors[] = 'CountUp.js faltante.';
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Cutting Data – Paso&nbsp;6</title>
   <?php
-    $bootstrapCss = $cssBootstrapRel
-      ?: 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css';
     $styles = [
-      $bootstrapCss,
+      $cssBootstrapRel,
       'assets/css/settings/settings.css',
       'assets/css/generic/generic.css',
       'assets/css/elements/elements.css',
@@ -269,12 +273,10 @@ if (!file_exists($countUpLocal)) $assetErrors[] = 'CountUp.js faltante.';
     ];
     include __DIR__ . '/../partials/styles.php';
   ?>
-  <?php if (!$embedded): ?>
-    <script>
-      window.BASE_URL  = <?= json_encode(BASE_URL) ?>;
-      window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
-    </script>
-  <?php endif; ?>
+  <script>
+    window.BASE_URL  = <?= json_encode(BASE_URL) ?>;
+    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
+  </script>
 </head>
 <body>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- refactor step6.php session logic and validation
- consolidate asset checks in styles.php
- clean up bootstrap handling and single HTML wrapper in step6
- document AJAX endpoint and update JS defaults
- adjust slider locking logic

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858af8564c0832c8718ace8c6ca5691