### PR TITLE
Improve reset and cleanup

### DIFF
--- a/assets/js/welcome_init.js
+++ b/assets/js/welcome_init.js
@@ -28,7 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   btnStart.addEventListener('click', () => {
     console.group("%c[WelcomeInit🛡️] Click en INICIAR","color:#4caf50;font-weight:bold");
-    console.log("🗡️ Desatando reset épico de sesión... ", `${BASE_URL}/public/reset.php`);
+    console.log("🗡️ Desatando reset ÉPICO de sesión... ", `${BASE_URL}/public/reset.php`);
 
     // Llamada al reset en backend
     fetch(`${BASE_URL}/public/reset.php`, { method: 'GET' })
@@ -36,7 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
-        console.log("🔄 Sesión PHP destruida con éxito.");
+        console.log("🔄 Núcleo PHP aniquilado con gloria.");
       })
       .catch(err => {
         console.warn("⚠️ Error destruyendo sesión:", err);
@@ -45,6 +45,8 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log("🧹 Limpiando progreso en localStorage...");
         localStorage.removeItem('wizard_progress');
         console.log("✅ localStorage limpio.");
+
+        console.log("🛰️ Sincronización total completada.");
 
         const nextUrl = `${BASE_URL}/wizard.php?state=mode`;
         console.log("🚀 Redirigiendo a selección de modo:", nextUrl);

--- a/public/reset.php
+++ b/public/reset.php
@@ -87,19 +87,31 @@ foreach (glob("$sessionFiles/sess_*") as $file) {
 }
 dbg('🧨 Archivos de sesión eliminados');
 
-// [G] Forzar nueva sesión limpia
+// [G] Purgar cachés de servidor para evitar desincronización
+if (function_exists('apcu_clear_cache')) {
+    apcu_clear_cache();
+    dbg('⚡ Caché APCu limpiada');
+}
+if (function_exists('opcache_reset')) {
+    opcache_reset();
+    dbg('🐘 OPcache reiniciada');
+}
+clearstatcache();
+dbg('📇 Cachés de estado de archivos limpiadas');
+
+// [H] Forzar nueva sesión limpia
 session_start();
 session_regenerate_id(true);
 session_destroy();
 dbg('🔄 Nueva sesión limpia generada');
 
-// [H] HTML de destrucción y redirección
+// [I] HTML de destrucción y redirección
 ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
   <meta charset="UTF-8">
-  <title>Reiniciando Wizard CNC...</title>
+  <title>Reset Épico del Wizard CNC</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="<?= asset('assets/css/generic/reset.css') ?>">
   <script>
@@ -108,8 +120,8 @@ dbg('🔄 Nueva sesión limpia generada');
 </head>
 <body class="center-screen">
   <div class="message-box">
-    <h1>Reiniciando Wizard CNC...</h1>
-    <p>Espere un instante...</p>
+    <h1>¡Reset total en progreso!</h1>
+    <p>Destruyendo reliquias y sincronizando el universo...</p>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- upgrade reset.php to wipe APCu and OPcache caches
- intensify reset HTML text and logs
- beef up welcome JS log messages

## Testing
- `npm run lint:css` *(fails: 131 problems)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68595e58d07c832ca36661739b882e48