### PR TITLE
Fix step6 script injection

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -640,11 +640,11 @@ if (!file_exists($countUpLocal))
 
 <!-- SCRIPTS -->
 <script>window.step6Params = <?= $jsonParams ?>; window.step6Csrf = '<?= $csrfToken ?>';</script>
+<?php if (!$embedded): ?>
 <script src="<?= $bootstrapJsRel ?>"></script>
 <script src="<?= asset('node_modules/feather-icons/dist/feather.min.js') ?>"></script>
 <script src="<?= asset('node_modules/chart.js/dist/chart.umd.min.js') ?>"></script>
 <script src="<?= asset('node_modules/countup.js/dist/countUp.umd.js') ?>"></script>
-<?php if (!$embedded): ?>
 <script src="<?= $step6JsRel ?>"></script>
 <?php endif; ?>
 <script>feather.replace();</script>


### PR DESCRIPTION
## Summary
- avoid loading core libraries inside step6 when embedded to prevent conflicts

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596552e7e0832ca360084e1a218534