### PR TITLE
Fix missing chart dependencies for step 6

### DIFF
--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -83,6 +83,9 @@
   <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
   <script>feather.replace();</script>
   <script src="<?= asset('assets/js/bootstrap.bundle.min.js') ?>"></script>
+  <!-- Step 6 dependencies -->
+  <script src="<?= asset('node_modules/chart.js/dist/chart.umd.min.js') ?>" defer></script>
+  <script src="<?= asset('node_modules/countup.js/dist/countUp.umd.js') ?>" defer></script>
   <script src="<?= asset('assets/js/wizard_stepper.js') ?>" defer></script>
   <script src="<?= asset('assets/js/dashboard.js') ?>" defer></script>
 


### PR DESCRIPTION
## Summary
- include Chart.js and CountUp.js globally so Step 6 loads correctly

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685982d24dd0832cb75548b046b83db5