### PR TITLE
Fix Feather initialization timing

### DIFF
--- a/assets/js/wizard_stepper.js
+++ b/assets/js/wizard_stepper.js
@@ -116,7 +116,9 @@
         runStepScripts(stepHolder);
 
         // Inicializadores JS globales (Feather, Bootstrap tooltips)
-        if (window.feather) feather.replace();
+        if (window.feather) {
+          requestAnimationFrame(() => feather.replace());
+        }
         if (window.bootstrap && bootstrap.Tooltip) {
           document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
             new bootstrap.Tooltip(el);

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -647,7 +647,9 @@ if (!file_exists($countUpLocal))
 <script src="<?= asset('node_modules/countup.js/dist/countUp.umd.js') ?>"></script>
 <script src="<?= $step6JsRel ?>"></script>
 <?php endif; ?>
+<?php if (!$embedded): ?>
 <script>feather.replace();</script>
+<?php endif; ?>
 
 <?php if (!$embedded): ?>
 </body>


### PR DESCRIPTION
## Summary
- avoid duplicate feather.replace by skipping in embedded step6
- delay icon replacement in wizard_stepper.js until next frame

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685988e0ecb0832cac918f752ca1e862