### PR TITLE
Fix deprecated filter usage and error handling

### DIFF
--- a/wizard.php
+++ b/wizard.php
@@ -68,7 +68,8 @@ startSecureSession();
 // [E] OVERRIDE DE ESTADO “mode” POR GET
 //     Y LIMPIEZA DE localStorage
 // -------------------------------------------
-if (filter_input(INPUT_GET, 'state', FILTER_SANITIZE_STRING) === 'mode') {
+$stateRaw = filter_input(INPUT_GET, 'state', FILTER_UNSAFE_RAW);
+if (trim($stateRaw) === 'mode') {
     $_SESSION['wizard_state'] = 'mode';
     session_regenerate_id(true);
     dbg('⤴ Forzado a estado = mode vía GET');
@@ -101,7 +102,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['tool_mode'])) {
     }
 
     // Saneamiento y validación de “tool_mode”
-    $modeRaw = filter_input(INPUT_POST, 'tool_mode', FILTER_SANITIZE_STRING) ?? '';
+    $modeRaw = filter_input(INPUT_POST, 'tool_mode', FILTER_UNSAFE_RAW);
+    $modeRaw = trim($modeRaw ?? '');
     $mode = ($modeRaw === 'auto') ? 'auto' : 'manual';
 
     // Guardar en sesión


### PR DESCRIPTION
## Summary
- replace deprecated `FILTER_SANITIZE_STRING` with `FILTER_UNSAFE_RAW` and trimming
- route early errors in step6 through `respondError`

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859be19eb1c832ca314ffd8fcd14a49