### PR TITLE
Fix step6 DOM using backup layout

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -11,7 +11,7 @@
 window.radarChartInstance = window.radarChartInstance || null;
 
 window.initStep6 = function () {
-  const BASE_URL = window.BASE_URL;
+  const BASE_URL = window.BASE_URL || '';
   const DEBUG = window.DEBUG ?? false;
   const TAG = '[WizardStepper]';
   const logger = (lvl, ...a) => { if (!DEBUG) return; const ts = new Date().toISOString(); console[lvl](`${TAG} ${ts}`, ...a); };
@@ -220,7 +220,8 @@ window.initStep6 = function () {
           'X-CSRF-Token': csrfToken
         },
         body: JSON.stringify(payload),
-        cache: 'no-store'
+        cache: 'no-store',
+        credentials: 'same-origin'
       });
       if (res.status === 403) {
         return showError('Sesión expirada. Recargá la página.');

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -238,40 +238,22 @@ if (!file_exists($countUpLocal))
 // =========================  COMIENZA SALIDA  ==========================
 // =====================================================================
 ?>
-<?php if (! $embedded): ?>
+<?php if (!$embedded): ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Cutting Data – Paso&nbsp;6</title>
-  <?php
-    $styles = [
-      $cssBootstrapRel,
-      'assets/css/settings/settings.css',
-      'assets/css/generic/generic.css',
-      'assets/css/elements/elements.css',
-      'assets/css/objects/objects.css',
-      'assets/css/objects/wizard.css',
-      'assets/css/objects/stepper.css',
-      'assets/css/objects/step-common.css',
-      'assets/css/objects/step6.css',
-      'assets/css/components/components.css',
-      'assets/css/components/main.css',
-      'assets/css/components/footer-schneider.css',
-      'assets/css/utilities/utilities.css',
-    ];
-    include __DIR__ . '/../partials/styles.php';
-  ?>
-  <script>
-    window.BASE_URL  = <?= json_encode(BASE_URL) ?>;
-    window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
-  </script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Cutting Data – Paso 6</title>
+  <link href="<?= $cssBootstrapRel ?>" rel="stylesheet">
+  <link rel="stylesheet" href="<?= asset('assets/css/step6.css') ?>">
+
 </head>
 <body>
 <?php endif; ?>
 
-<?php if ($assetErrors): ?>
+<!-- ALERTA DE ASSETS FALTANTES -->
+<?php if (!empty($assetErrors)): ?>
   <div class="alert alert-warning text-dark m-3">
     <strong>⚠️ Archivos faltantes (se usarán CDNs):</strong>
     <ul>
@@ -282,249 +264,267 @@ if (!file_exists($countUpLocal))
   </div>
 <?php endif; ?>
 
-<div class="step6">
-<div class="content-main">
-  <div class="container py-4">
-    <h2 class="step-title"><i data-feather="bar-chart-2"></i> Resultados</h2>
-    <p class="step-desc">Ajustá los parámetros y revisá los datos de corte.</p>
-  <!-- BLOQUE CENTRAL -->
-  <div class="row gx-3 mb-4 cards-grid">
-    <div class="col-12 col-lg-4 mb-3 area-tool">
-      <div class="card h-100 shadow-sm">
-        <div class="card-header text-center p-3">
-          <span>#<?= $serialNumber ?> – <?= $toolCode ?></span>
-        </div>
-        <div class="card-body text-center p-4">
-          <?php if ($imageURL): ?>
-            <img src="<?= htmlspecialchars($imageURL, ENT_QUOTES) ?>"
-                 alt="Imagen principal herramienta"
-                 class="tool-image mx-auto d-block">
-          <?php else: ?>
-            <div class="text-secondary">Sin imagen disponible</div>
-          <?php endif; ?>
-          <div class="tool-name mt-3"><?= $toolName ?></div>
-          <div class="tool-type"><?= $toolType ?></div>
+<!-- BLOQUE CENTRAL HTML -->
+<div class="container-fluid py-3 content-main dashboard-grid">
+  <!-- ENCABEZADO DE HERRAMIENTA -->
+  <div class="container py-3">
+    <div class="row gx-3 mb-4">
+      <div class="col-12 col-lg-4 mb-3 area-tool">
+        <div class="card h-100 shadow-sm">
+          <div class="card-header text-center p-3">
+            <span>#<?= $serialNumber ?> – <?= $toolCode ?></span>
+          </div>
+          <div class="card-body text-center p-4">
+            <?php if (!empty($toolData['image'])): ?>
+              <img
+                src="<?= htmlspecialchars($imageURL, ENT_QUOTES) ?>"
+                alt="Imagen principal de la herramienta"
+                class="tool-image mx-auto d-block"
+              >
+            <?php else: ?>
+              <div class="text-secondary">Sin imagen disponible</div>
+            <?php endif; ?>
+            <div class="tool-name mt-3"><?= $toolName ?></div>
+            <div class="tool-type"><?= $toolType ?></div>
+          </div>
         </div>
       </div>
     </div>
   </div>
 
-  <!-- AJUSTES / RESULTADOS / RADAR -->
-  <div class="row gx-3 mb-4 cards-grid">
-    <!-- Ajustes -->
-    <div class="col-12 col-lg-4 mb-3 area-sliders">
-      <div class="card h-100 shadow-sm">
-        <div class="card-header text-center p-3"><h5 class="mb-0">Ajustes</h5></div>
-        <div class="card-body p-4">
-          <!-- fz -->
-          <div class="mb-4 px-2">
-            <label for="sliderFz" class="form-label">fz (mm/tooth)</label>
-            <div class="slider-wrap">
-              <input type="range" id="sliderFz" class="form-range"
-                     min="<?= number_format($fzMinDb,4,'.','') ?>"
-                     max="<?= number_format($fzMaxDb,4,'.','') ?>"
-                     step="0.0001"
-                     value="<?= number_format($baseFz,4,'.','') ?>">
-              <span class="slider-bubble"></span>
-            </div>
-            <div class="text-end small text-secondary mt-1">
-              <span><?= number_format($fzMinDb,4,'.','') ?></span> –
-              <strong id="valFz"><?= number_format($baseFz,4,'.','') ?></strong> –
-              <span><?= number_format($fzMaxDb,4,'.','') ?></span>
-            </div>
-          </div>
-          <!-- Vc -->
-          <div class="mb-4 px-2">
-            <label for="sliderVc" class="form-label">Vc (m/min)</label>
-            <div class="slider-wrap">
-              <input type="range" id="sliderVc" class="form-range"
-                     min="<?= number_format($vcMinDb,1,'.','') ?>"
-                     max="<?= number_format($vcMaxDb,1,'.','') ?>"
-                     step="0.1"
-                     value="<?= number_format($baseVc,1,'.','') ?>">
-              <span class="slider-bubble"></span>
-            </div>
-            <div class="text-end small text-secondary mt-1">
-              <span><?= number_format($vcMinDb,1,'.','') ?></span> –
-              <strong id="valVc"><?= number_format($baseVc,1,'.','') ?></strong> –
-              <span><?= number_format($vcMaxDb,1,'.','') ?></span>
-            </div>
-          </div>
-          <!-- ae -->
-          <div class="mb-4 px-2">
-            <label for="sliderAe" class="form-label">
-              ae (mm) <small>(ancho de pasada)</small>
-            </label>
-            <div class="slider-wrap">
-              <input type="range" id="sliderAe" class="form-range"
-                     min="0.1"
-                     max="<?= number_format($diameterMb,1,'.','') ?>"
-                     step="0.1"
-                     value="<?= number_format($diameterMb * 0.5,1,'.','') ?>">
-              <span class="slider-bubble"></span>
-            </div>
-            <div class="text-end small text-secondary mt-1">
-              <span>0.1</span> –
-              <strong id="valAe"><?= number_format($diameterMb * 0.5,1,'.','') ?></strong> –
-              <span><?= number_format($diameterMb,1,'.','') ?></span>
-            </div>
-          </div>
-          <!-- Pasadas -->
-          <div class="mb-4 px-2">
-            <label for="sliderPasadas" class="form-label">Pasadas</label>
-            <div class="slider-wrap">
-              <input type="range" id="sliderPasadas" class="form-range"
-                     min="1" max="1" step="1"
-                     value="1"
-                     data-thickness="<?= htmlspecialchars((string)$thickness, ENT_QUOTES) ?>">
-              <span class="slider-bubble"></span>
-            </div>
-            <div id="textPasadasInfo" class="small text-secondary mt-1">
-              1 pasada de <?= number_format($thickness, 2) ?> mm
-            </div>
-            <div id="errorMsg" class="text-danger mt-2 small"></div>
-          </div>
-        </div>
-      </div>
-    </div>
+  <!-- FILA: Sliders / Resultados / Radar -->
+  <div class="container py-3">
+    <div class="row gx-3 mb-4">
 
-    <!-- Resultados -->
-    <div class="col-12 col-lg-4 mb-3 area-results">
-      <div class="card h-100 shadow-sm">
-        <div class="card-header text-center p-3"><h5 class="mb-0">Resultados</h5></div>
-        <div class="card-body p-4">
-          <div class="results-compact mb-4 d-flex gap-2">
-            <div class="result-box text-center flex-fill">
-              <div class="param-label">
-                Feedrate<br><small>(<span class="param-unit">mm/min</span>)</small>
+      <!-- 1) Ajustes (Sliders) -->
+      <div class="col-12 col-lg-4 mb-3 area-sliders">
+        <div class="card h-100 shadow-sm">
+          <div class="card-header text-center p-3">
+            <h5 class="mb-0">Ajustes</h5>
+          </div>
+          <div class="card-body p-4">
+            <!-- fz -->
+            <div class="mb-4 px-2">
+              <label for="sliderFz" class="form-label">fz (mm/tooth)</label>
+              <input
+                type="range"
+                id="sliderFz"
+                class="form-range"
+                min="<?= number_format($fzMinDb,4,'.','') ?>"
+                max="<?= number_format($fzMaxDb,4,'.','') ?>"
+                step="0.0001"
+                value="<?= number_format($baseFz,4,'.','') ?>"
+              >
+              <div class="text-end small text-secondary mt-1">
+                <span><?= number_format($fzMinDb,4,'.','') ?></span> –
+                <strong id="valFz"><?= number_format($baseFz,4,'.','') ?></strong> –
+                <span><?= number_format($fzMaxDb,4,'.','') ?></span>
               </div>
-              <div id="outVf" class="fw-bold display-6"><?= $outVf ?></div>
             </div>
-            <div class="result-box text-center flex-fill">
-              <div class="param-label">
-                Cutting speed<br><small>(<span class="param-unit">RPM</span>)</small>
+            <!-- Vc -->
+            <div class="mb-4 px-2">
+              <label for="sliderVc" class="form-label">Vc (m/min)</label>
+              <input
+                type="range"
+                id="sliderVc"
+                class="form-range"
+                min="<?= number_format($vcMinDb,1,'.','') ?>"
+                max="<?= number_format($vcMaxDb,1,'.','') ?>"
+                step="0.1"
+                value="<?= number_format($baseVc,1,'.','') ?>"
+              >
+              <div class="text-end small text-secondary mt-1">
+                <span><?= number_format($vcMinDb,1,'.','') ?></span> –
+                <strong id="valVc"><?= number_format($baseVc,1,'.','') ?></strong> –
+                <span><?= number_format($vcMaxDb,1,'.','') ?></span>
               </div>
-              <div id="outN" class="fw-bold display-6"><?= $outN ?></div>
             </div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mb-2">
-            <small>Vc</small>
-            <div><span id="outVc" class="fw-bold"><?= $outVc ?></span> <span class="param-unit">m/min</span></div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mb-2">
-            <small>fz</small>
-            <div><span id="outFz" class="fw-bold">--</span> <span class="param-unit">mm/tooth</span></div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mb-2">
-            <small>Ap</small>
-            <div><span id="outAp" class="fw-bold">--</span> <span class="param-unit">mm</span></div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mb-2">
-            <small>Ae</small>
-            <div><span id="outAe" class="fw-bold">--</span> <span class="param-unit">mm</span></div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mb-2">
-            <small>hm</small>
-            <div><span id="outHm" class="fw-bold">--</span> <span class="param-unit">mm</span></div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mb-3">
-            <small>Hp</small>
-            <div><span id="outHp" class="fw-bold">--</span> <span class="param-unit">HP</span></div>
-          </div>
-          <!-- Métricas secundarias -->
-          <div class="d-flex justify-content-between align-items-center mb-3">
-            <div class="param-label">
-              MMR<br><small>(<span class="param-unit">mm³/min</span>)</small>
+            <!-- ae -->
+            <div class="mb-4 px-2">
+              <label for="sliderAe" class="form-label">
+                ae (mm) <small>(ancho de pasada)</small>
+              </label>
+              <input
+                type="range"
+                id="sliderAe"
+                class="form-range"
+                min="0.1"
+                max="<?= number_format($diameterMb,1,'.','') ?>"
+                step="0.1"
+                value="<?= number_format($diameterMb*0.5,1,'.','') ?>"
+              >
+              <div class="text-end small text-secondary mt-1">
+                <span>0.1</span> –
+                <strong id="valAe"><?= number_format($diameterMb*0.5,1,'.','') ?></strong> –
+                <span><?= number_format($diameterMb,1,'.','') ?></span>
+              </div>
             </div>
-            <div id="valueMrr" class="fw-bold">--</div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mb-3">
-            <div class="param-label">
-              Fc<br><small>(<span class="param-unit">N</span>)</small>
+            <!-- Pasadas -->
+            <div class="mb-4 px-2">
+              <label for="sliderPasadas" class="form-label">Pasadas</label>
+              <input
+                type="range"
+                id="sliderPasadas"
+                class="form-range"
+                min="1"
+                max="1"
+                step="1"
+                value="1"
+                data-thickness="<?= htmlspecialchars((string)$thickness, ENT_QUOTES) ?>"
+              >
+              <div id="textPasadasInfo" class="small text-secondary mt-1">
+                1 pasada de <?= number_format($thickness, 2) ?> mm
+              </div>
+              <div id="errorMsg" class="text-danger mt-2 small" style="display:none"></div>
             </div>
-            <div id="valueFc" class="fw-bold">--</div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mb-3">
-            <div class="param-label">
-              Potencia<br><small>(<span class="param-unit">W</span>)</small>
-            </div>
-            <div id="valueW" class="fw-bold">--</div>
-          </div>
-          <div class="d-flex justify-content-between align-items-center mb-3">
-            <div class="param-label">
-              η<br><small>(<span class="param-unit">%</span>)</small>
-            </div>
-            <div id="valueEta" class="fw-bold">--</div>
           </div>
         </div>
       </div>
-    </div>
 
-    <!-- Radar Chart -->
-    <div class="col-12 col-lg-4 mb-3 area-radar">
-      <div class="card h-100 shadow-sm">
-        <div class="card-header text-center p-3"><h5 class="mb-0">Distribución Radar</h5></div>
-        <div class="card-body p-4 d-flex justify-content-center align-items-center">
-          <canvas id="radarChart" width="300" height="300"></canvas>
+      <!-- 2) Resultados -->
+      <div class="col-12 col-lg-4 mb-3 area-results">
+        <div class="card h-100 shadow-sm">
+          <div class="card-header text-center p-3">
+            <h5 class="mb-0">Resultados</h5>
+          </div>
+          <div class="card-body p-4">
+            <!-- Compact feedrate & speed -->
+            <div class="results-compact mb-4 d-flex gap-2">
+              <div class="result-box text-center flex-fill">
+                <div class="param-label">
+                  Feedrate<br><small>(<span class="param-unit">mm/min</span>)</small>
+                </div>
+                <div id="outVf" class="fw-bold display-6"><?= $outVf ?? '--' ?></div>
+              </div>
+              <div class="result-box text-center flex-fill">
+                <div class="param-label">
+                  Cutting speed<br><small>(<span class="param-unit">RPM</span>)</small>
+                </div>
+                <div id="outN" class="fw-bold display-6"><?= $outVc ?? '--' ?></div>
+              </div>
+            </div>
+            <!-- Detalle métricas -->
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <small>Vc</small>
+              <div><span id="outVc" class="fw-bold">--</span> <span class="param-unit">m/min</span></div>
+            </div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <small>fz</small>
+              <div><span id="outFz" class="fw-bold">--</span> <span class="param-unit">mm/tooth</span></div>
+            </div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <small>Ap</small>
+              <div><span id="outAp" class="fw-bold">--</span> <span class="param-unit">mm</span></div>
+            </div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <small>Ae</small>
+              <div><span id="outAe" class="fw-bold">--</span> <span class="param-unit">mm</span></div>
+            </div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <small>hm</small>
+              <div><span id="outHm" class="fw-bold">--</span> <span class="param-unit">mm</span></div>
+            </div>
+            <div class="d-flex justify-content-between align-items-center mb-3">
+              <small>Hp</small>
+              <div><span id="outHp" class="fw-bold">--</span> <span class="param-unit">HP</span></div>
+            </div>
+
+            <!-- Métricas secundarias -->
+            <div class="rd-flex justify-content-between align-items-center mb-3">
+
+                <div class="param-label">MMR<br><small>(<span class="param-unit">mm³/min</span>)</small></div>
+                <div id="valueMrr" class="fw-bold">--</div>
+
+              <div class="d-flex justify-content-between align-items-center mb-3">
+                <div class="param-label">Fc<br><small>(<span class="param-unit">N</span>)</small></div>
+                <div id="valueFc" class="fw-bold">--</div>
+              </div>
+              <div class="rd-flex justify-content-between align-items-center mb-3">
+                <div class="param-label">Potencia<br><small>(<span class="param-unit">W</span>)</small></div>
+                <div id="valueW" class="fw-bold">--</div>
+              </div>
+              <div class="d-flex justify-content-between align-items-center mb-3">
+                <div class="param-label">η<br><small>(<span class="param-unit">%</span>)</small></div>
+                <div id="valueEta" class="fw-bold">--</div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
 
-  <!-- ESPECIFICACIONES / CONFIGURACIÓN / NOTAS -->
-  <div class="row gx-3 mb-4 cards-grid">
-    <!-- Especificaciones -->
-    <div class="col-12 col-lg-4 mb-3">
-      <div class="card h-100 shadow-sm">
-        <div class="card-header text-center p-3"
-             data-bs-toggle="collapse"
-             data-bs-target="#specCollapse"
-             aria-expanded="true">
-          <h5 class="mb-0">Especificaciones Técnicas</h5>
+      <!-- 3) Radar Chart -->
+      <div class="col-12 col-lg-4 mb-3 area-radar">
+        <div class="card h-100 shadow-sm">
+          <div class="card-header text-center p-3">
+            <h5 class="mb-0">Distribución Radar</h5>
+          </div>
+          <div class="card-body p-4 d-flex justify-content-center align-items-center">
+            <canvas id="radarChart" width="10%" height="50"></canvas>
+          </div>
         </div>
-        <div id="specCollapse" class="collapse show">
+      </div>
+
+
+
+  <!-- ESPECIFICACIONES TÉCNICAS & IMAGEN VECTORIAL -->
+  <div class="container py-3">
+    <div class="row gx-3 mb-4">
+
+      <div class="col-12 col-lg-4 mb-3">
+        <div class="card h-100 shadow-sm">
+          <div class="card-header text-center p-3">
+            <h5 class="mb-0">Especificaciones Técnicas</h5>
+          </div>
           <div class="card-body p-4">
             <div class="row gx-0 align-items-center">
-              <div class="col-12 col-lg-7 px-2 mb-4 mb-lg-0">
+              <!-- Izquierda: especificaciones -->
+              <div class="col-12 col-lg-6 px-2 mb-4 mb-lg-0">
                 <ul class="spec-list mb-0 px-2">
                   <li><span>Diámetro de corte (d1):</span>
-                      <span><?= number_format($diameterMb,3,'.','') ?>
-                      <span class="param-unit">mm</span>
-                      </span>
+                      <span><?= number_format($diameterMb,3,'.','') ?> <span class="param-unit">mm</span></span>
                   </li>
                   <li><span>Diámetro del vástago:</span>
-                      <span><?= number_format($shankMb,3,'.','') ?>
-                      <span class="param-unit">mm</span>
-                      </span>
+                      <span><?= number_format($shankMb,3,'.','') ?> <span class="param-unit">mm</span></span>
                   </li>
                   <li><span>Longitud de corte:</span>
-                      <span><?= number_format($cutLenMb,3,'.','') ?>
-                      <span class="param-unit">mm</span>
-                      </span>
+                      <span><?= number_format($cutLenMb,3,'.','') ?> <span class="param-unit">mm</span></span>
                   </li>
                   <li><span>Longitud de filo:</span>
-                      <span><?= number_format($fluteLenMb,3,'.','') ?>
-                      <span class="param-unit">mm</span>
-                      </span>
+                      <span><?= number_format($fluteLenMb,3,'.','') ?> <span class="param-unit">mm</span></span>
                   </li>
                   <li><span>Longitud total:</span>
-                      <span><?= number_format($fullLenMb,3,'.','') ?>
-                      <span class="param-unit">mm</span>
-                      </span>
+                      <span><?= number_format($fullLenMb,3,'.','') ?> <span class="param-unit">mm</span></span>
                   </li>
-                  <li><span>Número de filos (Z):</span><span><?= $fluteCountMb ?></span></li>
-                  <li><span>Tipo de punta:</span><span><?= $toolType ?></span></li>
-                  <li><span>Recubrimiento:</span><span><?= $coatingMb ?></span></li>
-                  <li><span>Material fabricación:</span><span><?= $materialMb ?></span></li>
-                  <li><span>Marca:</span><span><?= $brandMb ?></span></li>
-                  <li><span>País de origen:</span><span><?= $madeInMb ?></span></li>
+                  <li><span>Número de filos (Z):</span>
+                      <span><?= $fluteCountMb ?></span>
+                  </li>
+                  <li><span>Tipo de punta:</span>
+                      <span><?= htmlspecialchars($toolType,ENT_QUOTES) ?></span>
+                  </li>
+                  <li><span>Recubrimiento:</span>
+                      <span><?= htmlspecialchars($coatingMb,ENT_QUOTES) ?></span>
+                  </li>
+                  <li><span>Material fabricación:</span>
+                      <span><?= htmlspecialchars($materialMb,ENT_QUOTES) ?></span>
+                  </li>
+                  <li><span>Marca:</span>
+                      <span><?= htmlspecialchars($brandMb,ENT_QUOTES) ?></span>
+                  </li>
+                  <li><span>País de origen:</span>
+                      <span><?= htmlspecialchars($madeInMb,ENT_QUOTES) ?></span>
+                  </li>
                 </ul>
               </div>
+              <!-- Divider vertical en desktop -->
+              <div class="d-none d-lg-block divider-vertical"></div>
+              <!-- Derecha: imagen vectorial -->
               <div class="col-12 col-lg-5 px-2 d-flex justify-content-center align-items-center">
                 <?php if ($vectorURL): ?>
-                  <img src="<?= htmlspecialchars($vectorURL, ENT_QUOTES) ?>"
-                       alt="Imagen vectorial herramienta"
-                       class="vector-image mx-auto d-block">
+                  <img
+                    src="<?= htmlspecialchars($vectorURL,ENT_QUOTES) ?>"
+                    alt="Imagen vectorial de la herramienta"
+                    class="vector-image mx-auto d-block"
+                  >
                 <?php else: ?>
                   <div class="text-secondary">Sin imagen vectorial</div>
                 <?php endif; ?>
@@ -533,28 +533,23 @@ if (!file_exists($countUpLocal))
           </div>
         </div>
       </div>
-    </div>
 
-    <!-- Configuración -->
-    <div class="col-12 col-lg-4 mb-3">
-      <div class="card h-100 shadow-sm">
-        <div class="card-header text-center p-3"
-             data-bs-toggle="collapse"
-             data-bs-target="#configCollapse"
-             aria-expanded="true">
-          <h5 class="mb-0">Configuración de Usuario</h5>
-        </div>
-        <div id="configCollapse" class="collapse show">
+      <!-- CONFIGURACIÓN DE USUARIO -->
+      <div class="col-12 col-lg-4 mb-3">
+        <div class="card h-100 shadow-sm">
+          <div class="card-header text-center p-3">
+            <h5 class="mb-0">Configuración de Usuario</h5>
+          </div>
           <div class="card-body p-4">
             <div class="config-section mb-3">
               <div class="config-section-title">Material</div>
               <div class="config-item">
                 <div class="label-static">Categoría padre:</div>
-                <div class="value-static"><?= $materialParent ?></div>
+                <div class="value-static"><?= htmlspecialchars($materialParent ?? '', ENT_QUOTES) ?></div>
               </div>
               <div class="config-item">
                 <div class="label-static">Material a mecanizar:</div>
-                <div class="value-static"><?= $materialName ?></div>
+                <div class="value-static"><?= htmlspecialchars($materialName ?? '', ENT_QUOTES) ?></div>
               </div>
             </div>
             <div class="section-divider"></div>
@@ -562,11 +557,11 @@ if (!file_exists($countUpLocal))
               <div class="config-section-title">Estrategia</div>
               <div class="config-item">
                 <div class="label-static">Categoría padre estr.:</div>
-                <div class="value-static"><?= $strategyParent ?></div>
+                <div class="value-static"><?= htmlspecialchars($strategyParent ?? '', ENT_QUOTES) ?></div>
               </div>
               <div class="config-item">
                 <div class="label-static">Estrategia de corte:</div>
-                <div class="value-static"><?= $strategyName ?></div>
+                <div class="value-static"><?= htmlspecialchars($strategyName ?? '', ENT_QUOTES) ?></div>
               </div>
             </div>
             <div class="section-divider"></div>
@@ -574,69 +569,71 @@ if (!file_exists($countUpLocal))
               <div class="config-section-title">Máquina</div>
               <div class="config-item">
                 <div class="label-static">Espesor del material:</div>
-                <div class="value-static"><?= number_format($thickness,2) ?> <span class="param-unit">mm</span></div>
+                <div class="value-static"><?= htmlspecialchars((string)$thickness,ENT_QUOTES) ?> <span class="param-unit">mm</span></div>
               </div>
-              <div class="config-item">
-                <div class="label-static">Tipo de transmisión:</div>
-                <div class="value-static"><?= $transName ?></div>
+              <div class="config-item"><div class="label-static">Tipo de transmisión:</div>
+                <div class="value-static"><?= htmlspecialchars($transName ?? '',ENT_QUOTES) ?></div>
               </div>
               <div class="config-item">
                 <div class="label-static">Feedrate máximo:</div>
-                <div class="value-static"><?= number_format($frMax,0) ?> <span class="param-unit">mm/min</span></div>
+                <div class="value-static"><?= htmlspecialchars((string)$frMax,ENT_QUOTES) ?> <span class="param-unit">mm/min</span></div>
               </div>
               <div class="config-item">
                 <div class="label-static">RPM mínima:</div>
-                <div class="value-static"><?= number_format($rpmMin,0) ?> <span class="param-unit">rev/min</span></div>
+                <div class="value-static"><?= htmlspecialchars((string)$rpmMin,ENT_QUOTES) ?> <span class="param-unit">rev/min</span></div>
               </div>
               <div class="config-item">
                 <div class="label-static">RPM máxima:</div>
-                <div class="value-static"><?= number_format($rpmMax,0) ?> <span class="param-unit">rev/min</span></div>
+                <div class="value-static"><?= htmlspecialchars((string)$rpmMax,ENT_QUOTES) ?> <span class="param-unit">rev/min</span></div>
               </div>
               <div class="config-item">
                 <div class="label-static">Potencia disponible:</div>
-                <div class="value-static"><?= number_format($powerAvail,1) ?> <span class="param-unit">HP</span></div>
+                <div class="value-static"><?= htmlspecialchars((string)$powerAvail,ENT_QUOTES) ?> <span class="param-unit">HP</span></div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <!-- Notas -->
-    <div class="col-12 col-lg-4 mb-3">
-      <div class="card h-100 shadow-sm">
-        <div class="card-header text-center p-3"><h5 class="mb-0">Notas Adicionales</h5></div>
-        <div class="card-body p-4">
-          <?php if ($notesArray): ?>
-            <ul class="notes-list mb-0">
-              <?php foreach ($notesArray as $note): ?>
-                <li class="mb-2 d-flex align-items-start">
-                  <i data-feather="file-text" class="me-2"></i>
-                  <div><?= htmlspecialchars($note, ENT_QUOTES) ?></div>
-                </li>
-              <?php endforeach; ?>
-            </ul>
-          <?php else: ?>
-            <div class="text-secondary">No hay notas adicionales para esta herramienta.</div>
-          <?php endif; ?>
+      <!-- NOTAS ADICIONALES -->
+      <div class="col-12 col-lg-4 mb-3">
+        <div class="card h-100 shadow-sm">
+          <div class="card-header text-center p-3">
+            <h5 class="mb-0">Notas Adicionales</h5>
+          </div>
+          <div class="card-body p-4">
+            <?php if (!empty($notesArray)): ?>
+              <ul class="notes-list mb-0">
+                <?php foreach ($notesArray as $note): ?>
+                  <li class="mb-2 d-flex align-items-start">
+                    <i data-feather="file-text" class="me-2"></i>
+                    <div><?= htmlspecialchars($note, ENT_QUOTES) ?></div>
+                  </li>
+                <?php endforeach; ?>
+              </ul>
+            <?php else: ?>
+              <div class="text-secondary">No hay notas adicionales para esta herramienta.</div>
+            <?php endif; ?>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
 </div>
-</div><!-- .content-main -->
-</div><!-- .step6 -->
-<section id="wizard-dashboard"></section>
 
-<!-- SCRIPTS -->
-<script>window.step6Params = <?= $jsonParams ?>; window.step6Csrf = '<?= $csrfToken ?>';</script>
+
+
+<!--  🔻  ⬇︎  Añade esto JUSTO ANTES de cargar step6.js  ⬇︎  🔻 -->
+<script>
+  /* parámetros técnicos precalculados en PHP */
+  window.step6Params = <?= $jsonParams ?>;
+
+  /* token CSRF para que step6.js lo reenvíe al endpoint */
+  window.step6Csrf   = '<?= $csrfToken ?>';
+</script>
+
+<script src="<?= asset('node_modules/chart.js/dist/chart.umd.min.js') ?>"></script>
+<script src="<?= $step6JsRel ?>"></script>
+
 <?php if (!$embedded): ?>
-<script src="<?= $bootstrapJsRel ?>" defer></script>
-<script src="<?= asset('node_modules/feather-icons/dist/feather.min.js') ?>" defer></script>
-<script src="<?= asset('node_modules/chart.js/dist/chart.umd.min.js') ?>" defer></script>
-<script src="<?= asset('node_modules/countup.js/dist/countUp.umd.js') ?>" defer></script>
-<script src="<?= $step6JsRel ?>" defer></script>
-<script>requestAnimationFrame(() => feather.replace());</script>
 </body>
 </html>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- adjust JS fetch to use `credentials: 'same-origin'`
- restore step6 DOM to the same structure as the provided backup

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859fc0debcc832c96f51bf9aa5787c8