### PR TITLE
Fix CNCCalculator import warning

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -11,8 +11,6 @@
 declare(strict_types=1);
 
 use App\Controller\ExpertResultController;
-use ToolModel;
-use CNCCalculator;
 
 require_once __DIR__ . '/../../src/Config/AppConfig.php';
 require_once __DIR__ . '/../../src/Utils/Session.php';


### PR DESCRIPTION
## Summary
- remove unused `CNCCalculator` import from `views/steps/step6.php`

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a15e1a6c0832c97cb9019869d2a45