### PR TITLE
Enhance DOM protection in wizard_stepper

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ When running with `?debug=1` in the URL you can access additional debug helpers:
 
 All these endpoints require debug mode.
 
+## DOM Safety
+
+The wizard stepper validates each loaded fragment to keep the DOM consistent:
+ - Blocks `<link>`, `<style>` and similar tags that could break the layout.
+ - Detects duplicate element IDs before executing any script.
+
 ## Running Tests
 
 Unit tests can be run with PHPUnit. From the project root execute:

--- a/assets/js/wizard_stepper.js
+++ b/assets/js/wizard_stepper.js
@@ -2,6 +2,7 @@
  * File: wizard_stepper.js
  * Descripción: Controlador principal del Wizard CNC (modo Stepper).
  * Versión blindada: evita errores de DOM, controla carga de scripts y eventos JS.
+ * Ahora bloquea etiquetas no permitidas y detecta IDs duplicados al cargar cada paso.
  */
 
 /* global feather, bootstrap */
@@ -33,6 +34,8 @@
     dbgBox.textContent = `[${ts}] ${txt}\n` + dbgBox.textContent;
   };
 
+  const INVALID_TAGS = 'html, head, body, link, style, meta, iframe, object, embed';
+
   if (!stepsBar.length || !stepHolder) {
     log('No es página de wizard – abortando script.');
     return;
@@ -54,11 +57,20 @@
   };
 
   const runStepScripts = container => group('runStepScripts', () => {
-    if (container.querySelector('html, head, body')) {
-      error('❌ DOM inválido: se encontraron etiquetas <html>, <head> o <body> embebidas.');
-      dbgMsg('❌ Error crítico: el paso contiene etiquetas duplicadas.');
+    if (container.querySelector(INVALID_TAGS)) {
+      error('❌ DOM inválido: se encontraron etiquetas no permitidas.');
+      dbgMsg('❌ Error crítico: el paso contiene etiquetas bloqueadas.');
       return;
     }
+
+    const dup = [...container.querySelectorAll('[id]')]
+      .find(el => document.querySelectorAll(`#${CSS.escape(el.id)}`).length > 1);
+    if (dup) {
+      error(`❌ DOM inválido: id duplicado '${dup.id}'.`);
+      dbgMsg('❌ Error crítico: id duplicado.');
+      return;
+    }
+
     [...container.querySelectorAll('script')].forEach(tag => {
       if (tag.src) {
         if (!document.querySelector(`head script[src="${tag.src}"]`)) {


### PR DESCRIPTION
## Summary
- harden script loader with invalid tag and duplicate ID checks
- document new DOM Safety features

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b567cf974832c8b6387abdfb23040