### PR TITLE
Implement dynamic CSP nonce headers

### DIFF
--- a/includes/security.php
+++ b/includes/security.php
@@ -60,3 +60,24 @@ function validate_csrf_token(?string $token): bool
     }
     return hash_equals($_SESSION['csrf_token'], $token);
 }
+
+/**
+ * Generate (once per request) and return a CSP nonce.
+ */
+function get_csp_nonce(): string
+{
+    static $nonce = null;
+    if ($nonce === null) {
+        $nonce = base64_encode(random_bytes(16));
+    }
+    return $nonce;
+}
+
+/**
+ * Build CSP header using the per-request nonce.
+ */
+function csp_nonce_header(): string
+{
+    $n = get_csp_nonce();
+    return "script-src 'nonce-$n' 'self'; style-src 'nonce-$n' 'self'";
+}

--- a/views/partials/styles.php
+++ b/views/partials/styles.php
@@ -23,6 +23,6 @@ foreach ($styles as $href) {
     echo '<link rel="stylesheet" href="'.$url.'">'.PHP_EOL;
 }
 if ($embedded) {
-    echo '<style>body{background-color:transparent!important;}</style>'.PHP_EOL;
+    echo '<style nonce="'.get_csp_nonce().'">body{background-color:transparent!important;}</style>'.PHP_EOL;
 }
 ?>

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -8,6 +8,7 @@
  */
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../includes/security.php';
 /**
  * File: C:\xampp\htdocs\wizard-stepper_git\views\steps\auto\step1.php
  *
@@ -27,7 +28,8 @@ require_once __DIR__ . '/../../../src/Utils/Session.php';
 sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
-header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");
+$csp = csp_nonce_header();
+header('Content-Security-Policy: ' . $csp);
 
 //
 // [B] Errores y Debug
@@ -209,7 +211,7 @@ dbg('children', $children);
     include __DIR__ . '/../../partials/styles.php';
   ?>
   <?php if (!$embedded): ?>
-  <script>
+  <script nonce="<?= get_csp_nonce() ?>">
     window.BASE_URL = <?= json_encode(BASE_URL) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
   </script>
@@ -293,7 +295,7 @@ dbg('children', $children);
     </div>
   </form>
 
-  <script>
+  <script nonce="<?= get_csp_nonce() ?>">
   //────────────────────────────────────────────────────────────────────
   // normalizeText: Quita tildes, pasa a minúsculas
   function normalizeText(str) {

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -8,6 +8,7 @@
  */
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../includes/security.php';
 /**
  * File: step2.php
  * ---------------------------------------------------------------
@@ -25,7 +26,8 @@ require_once __DIR__ . '/../../../src/Utils/Session.php';
 sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
-header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");
+$csp = csp_nonce_header();
+header('Content-Security-Policy: ' . $csp);
 
 // -------------------------------------------
 // [B] Errores y Debug
@@ -195,7 +197,7 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
     include __DIR__ . '/../../partials/styles.php';
   ?>
   <?php if (!$embedded): ?>
-  <script>
+  <script nonce="<?= get_csp_nonce() ?>">
     window.BASE_URL = <?= json_encode(BASE_URL) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
   </script>
@@ -264,7 +266,7 @@ $hasPrev   = is_int($prevType) && array_key_exists((int)$prevType, $types)
     </div>
   </form>
 
-  <script>
+  <script nonce="<?= get_csp_nonce() ?>">
   (function() {
     // Datos PHP → JS
     const types = <?= json_encode($types, JSON_UNESCAPED_UNICODE) ?>;

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -8,6 +8,7 @@
  */
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../includes/security.php';
 /**
  * File: C:\xampp\htdocs\wizard-stepper_git\views\steps\auto\step4.php
  *
@@ -23,7 +24,8 @@ require_once __DIR__ . '/../../../src/Utils/Session.php';
 sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
-header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");
+$csp = csp_nonce_header();
+header('Content-Security-Policy: ' . $csp);
 
 // ──────────────────────────────────────────────────────────────
 // [B] Errores y debug
@@ -156,7 +158,7 @@ if($tool){
     include __DIR__ . '/../../partials/styles.php';
   ?>
   <?php if (!$embedded): ?>
-  <script>
+<script nonce="<?= get_csp_nonce() ?>">
     window.BASE_URL = <?= json_encode(BASE_URL) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
   </script>

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -14,6 +14,7 @@
 
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../includes/security.php';
 
 // ──────────────── 1) Sesión y configuración segura ──────────────────
 if (session_status() !== PHP_SESSION_ACTIVE) {
@@ -28,8 +29,8 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
-$nonce = base64_encode(random_bytes(16));
-header("Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-$nonce'; style-src  'self' 'unsafe-inline';");
+$csp = csp_nonce_header();
+header('Content-Security-Policy: ' . $csp);
 
 // ──────────────── 2) Estado del wizard ──────────────────────────────
 // Si aún no se inició el wizard, lo inicializamos en Paso 1
@@ -146,7 +147,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     include __DIR__ . '/../../partials/styles.php';
   ?>
   <?php if (!$embedded): ?>
-  <script>
+  <script nonce="<?= get_csp_nonce() ?>">
     window.BASE_URL = <?= json_encode(BASE_URL) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
   </script>
@@ -255,7 +256,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   </script>
   <script type="module" src="<?= asset('assets/js/step1_manual_lazy_loader.js') ?>"></script>
 
-  <script type="module" nonce="<?= $nonce ?>">
+  <script type="module" nonce="<?= get_csp_nonce() ?>">
       import { initToolTable } from '<?= asset('assets/js/step1_manual_table_hook.js') ?>';
     initToolTable();
   </script>

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -8,6 +8,7 @@
  */
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../includes/security.php';
 /**
  * File: step3.php
  * ------------------------------------------------------------------
@@ -25,7 +26,8 @@ require_once __DIR__ . '/../../../src/Utils/Session.php';
 sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
-header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';");
+$csp = csp_nonce_header();
+header('Content-Security-Policy: ' . $csp);
 
 /* ──────────────────────────────────────────────────────
  * [B]  Errores & debug
@@ -196,7 +198,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     include __DIR__ . '/../../partials/styles.php';
   ?>
   <?php if (!$embedded): ?>
-  <script>
+  <script nonce="<?= get_csp_nonce() ?>">
     window.BASE_URL = <?= json_encode(BASE_URL) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
   </script>
@@ -260,7 +262,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <!-- Bootstrap Bundle -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
-<script>
+<script nonce="<?= get_csp_nonce() ?>">
 /* PHP → JS */
 const grouped = <?= json_encode($grouped, JSON_UNESCAPED_UNICODE) ?>;
 

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -8,6 +8,7 @@
  */
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+require_once __DIR__ . '/../../../includes/security.php';
 /**
  * File: views/steps/manual/step4.php
  * Paso 4 (Manual) – Selección de madera compatible
@@ -20,7 +21,8 @@ require_once __DIR__ . '/../../../src/Utils/Session.php';
 sendSecurityHeaders('text/html; charset=UTF-8');
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
-header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;");
+$nonce = get_csp_nonce();
+header("Content-Security-Policy: script-src 'nonce-$nonce' 'self' https://cdn.jsdelivr.net; style-src 'nonce-$nonce' 'self' https://cdn.jsdelivr.net");
 
 //
 // [B] Errores y Debug
@@ -153,7 +155,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
   include __DIR__ . '/../../partials/styles.php';
 ?>
 <?php if (!$embedded): ?>
-<script>
+<script nonce="<?= get_csp_nonce() ?>">
   window.BASE_URL = <?= json_encode(BASE_URL) ?>;
   window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
 </script>
@@ -214,7 +216,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
 
 </main>
 
-<script>
+<script nonce="<?= get_csp_nonce() ?>">
 function normalizeText(s){return s.normalize('NFD').replace(/[\u0300-\u036f]/g,'').toLowerCase();}
 
 const parents  = <?=json_encode($parents,JSON_UNESCAPED_UNICODE)?>;

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -121,7 +121,7 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
   include __DIR__ . '/../partials/styles.php';
 ?>
 <?php if (!$embedded): ?>
-<script>
+<script nonce="<?= get_csp_nonce() ?>">
   window.BASE_URL = <?= json_encode(BASE_URL) ?>;
   window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
 </script>
@@ -191,7 +191,7 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
   </form>
 </main>
 
-<script>
+<script nonce="<?= get_csp_nonce() ?>">
 (() => {
   const radios   = document.querySelectorAll('.btn-check');
   const paramSec = document.getElementById('paramSection');

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -5,6 +5,7 @@
  */
 
 declare(strict_types=1);
+require_once __DIR__ . '/../../includes/security.php';
 
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
@@ -93,7 +94,8 @@ if (!$embedded) {
     header('Referrer-Policy: no-referrer');
     header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
     header('Pragma: no-cache');
-    header("Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' https://cdn.jsdelivr.net");
+    $nonce = get_csp_nonce();
+    header("Content-Security-Policy: script-src 'nonce-$nonce' 'self' https://cdn.jsdelivr.net; style-src 'nonce-$nonce' 'self' https://cdn.jsdelivr.net");
 }
 
 // ------------------------------------------------------------------
@@ -364,7 +366,7 @@ if (!file_exists($countUpLocal))
     ];
     include __DIR__ . '/../partials/styles.php';
   ?>
-  <script>
+  <script nonce="<?= get_csp_nonce() ?>">
     window.BASE_URL  = <?= json_encode(BASE_URL) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
   </script>
@@ -730,14 +732,14 @@ if (!file_exists($countUpLocal))
 <section id="wizard-dashboard"></section>
 
 <!-- SCRIPTS -->
-<script>window.step6Params = <?= $jsonParams ?>; window.step6Csrf = '<?= $csrfToken ?>';</script>
+<script nonce="<?= get_csp_nonce() ?>">window.step6Params = <?= $jsonParams ?>; window.step6Csrf = '<?= $csrfToken ?>';</script>
 <?php if (!$embedded): ?>
 <script src="<?= $bootstrapJsRel ?>" defer></script>
 <script src="<?= asset('node_modules/feather-icons/dist/feather.min.js') ?>" defer></script>
 <script src="<?= asset('node_modules/chart.js/dist/chart.umd.min.js') ?>" defer></script>
 <script src="<?= asset('node_modules/countup.js/dist/countUp.umd.js') ?>" defer></script>
 <script src="<?= $step6JsRel ?>" defer></script>
-<script>requestAnimationFrame(() => feather.replace());</script>
+<script nonce="<?= get_csp_nonce() ?>">requestAnimationFrame(() => feather.replace());</script>
 </body>
 </html>
 <?php endif; ?>

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -7,6 +7,9 @@
  * Related files: includes/init.php, assets/css/objects/wizard.css, assets/css/components/main.css
  */
 require_once __DIR__ . '/../includes/init.php';
+require_once __DIR__ . '/../includes/security.php';
+$csp = csp_nonce_header();
+header('Content-Security-Policy: ' . $csp);
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -18,7 +21,7 @@ require_once __DIR__ . '/../includes/init.php';
   <link rel="stylesheet" href="<?= asset('assets/css/components/main.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/objects/wizard.css') ?>">
   <link rel="stylesheet" href="<?= asset('assets/css/components/onboarding.css') ?>">
-  <script>
+  <script nonce="<?= get_csp_nonce() ?>">
     window.BASE_URL = <?= json_encode(BASE_URL) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST) ?>;
   </script>
@@ -37,6 +40,6 @@ require_once __DIR__ . '/../includes/init.php';
   </main>
   <script src="<?= asset('assets/js/welcome_init.js') ?>"></script>
   <script src="https://unpkg.com/lucide@latest"></script>
-  <script>lucide.createIcons();</script>
+  <script nonce="<?= get_csp_nonce() ?>">lucide.createIcons();</script>
 </body>
 </html>

--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -48,7 +48,7 @@ declare(strict_types=1);
   <link rel="stylesheet" href="<?= asset('assets/css/generic/bootstrap.min.css') ?>">
 
   <!-- VARIABLES GLOBALES JS (inyectadas desde PHP con encoding seguro) -->
-  <script>
+  <script nonce="<?= get_csp_nonce() ?>">
     window.BASE_URL  = <?= json_encode(BASE_URL, JSON_UNESCAPED_SLASHES) ?>;
     window.BASE_HOST = <?= json_encode(BASE_HOST, JSON_UNESCAPED_SLASHES) ?>;
     window.DEBUG     = <?= $DEBUG ? 'true' : 'false' ?>;
@@ -89,14 +89,14 @@ declare(strict_types=1);
 
   <!-- TOKEN CSRF GLOBAL -->
   <?php if (!empty($_SESSION['csrf_token'])): ?>
-    <script>
+    <script nonce="<?= get_csp_nonce() ?>">
       window.csrfToken = '<?= htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8') ?>';
     </script>
   <?php endif; ?>
 
   <!-- ICONOS VECTORIALES -->
   <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
-  <script>requestAnimationFrame(() => feather.replace());</script>
+  <script nonce="<?= get_csp_nonce() ?>">requestAnimationFrame(() => feather.replace());</script>
 
   <!-- BOOTSTRAP Y JS CORE -->
   <script src="<?= asset('assets/js/bootstrap.bundle.min.js') ?>" defer></script>

--- a/wizard.php
+++ b/wizard.php
@@ -27,7 +27,9 @@ dbg('🔧 wizard.php iniciado');
 
 /* ──────────────── SESIÓN SEGURA ──────────────── */
 require_once __DIR__ . '/src/Utils/Session.php';
-sendSecurityHeaders('text/html; charset=UTF-8', 63072000, true);
+require_once __DIR__ . '/includes/security.php';
+$csp = csp_nonce_header();
+sendSecurityHeaders('text/html; charset=UTF-8', 63072000, true, $csp);
 startSecureSession();
 
 /* ──────────────── FORZAR ESTADO “mode” SI SE PIDE ──────────────── */
@@ -36,7 +38,7 @@ if (trim((string)$stateOverride) === 'mode') {
     $_SESSION['wizard_state'] = 'mode';
     session_regenerate_id(true);
     dbg('⤴ Forzado a estado = mode vía GET');
-    echo '<script>try{localStorage.removeItem("wizard_progress");}catch(e){}</script>';
+    echo '<script nonce="'.get_csp_nonce().'">try{localStorage.removeItem("wizard_progress");}catch(e){}</script>';
 }
 
 /* ──────────────── ESTADO POR DEFECTO ──────────────── */


### PR DESCRIPTION
## Summary
- generate per-request nonce helpers
- send CSP header with nonce from router and views
- apply nonce on inline scripts and styles

## Testing
- `vendor/bin/phpunit`
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_685b64dff17c832c902663eb30d15dee