### PR TITLE
Fix environment loading for DB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ This project contains a PHP wizard for configuring CNC operations.
    ```bash
    composer install
    ```
-2. Create a database called `cnc_calculador` (or adjust the name in `includes/db.php`).
+2. Create a database called `cnc_calculador` (or adjust the name in your `.env` file).
 3. Import `cnc_calculador.sql`:
    ```bash
    mysql -u <user> -p cnc_calculador < cnc_calculador.sql
    ```
-4. Adjust database credentials in `includes/db.php` if needed.
+4. Copy `.env.example` to `.env` and adjust the database credentials there.
 5. Start the application using PHP's built‑in server:
  ```bash
   php -S localhost:8000

--- a/includes/db.php
+++ b/includes/db.php
@@ -10,11 +10,17 @@
 declare(strict_types=1);
 
 /* ───────── CONFIG DB ───────── */
+// Load Composer autoloader if available (for Dotenv)
+if (is_readable(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}
+
 // Load environment variables from .env if present
-if (file_exists(__DIR__ . '/../.env')) {
+if (class_exists(Dotenv\Dotenv::class) && file_exists(__DIR__ . '/../.env')) {
+    Dotenv\Dotenv::createImmutable(dirname(__DIR__))->safeLoad();
+} elseif (file_exists(__DIR__ . '/../.env')) {
     $env = parse_ini_file(__DIR__ . '/../.env', false, INI_SCANNER_TYPED);
     if ($env !== false) {
-        // Merge .env values into $_ENV without overwriting existing entries
         foreach ($env as $key => $val) {
             if (!isset($_ENV[$key])) {
                 $_ENV[$key] = $val;


### PR DESCRIPTION
## Summary
- support loading env vars with `vlucas/phpdotenv` in `includes/db.php`
- clarify setup instructions for creating `.env` in README

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685b677fda34832c80689f6858cb62f1