### PR TITLE
Add additional security headers

### DIFF
--- a/public/load-step.php
+++ b/public/load-step.php
@@ -32,6 +32,8 @@ if (is_readable(ROOT_DIR . '/vendor/autoload.php')) {
     require_once ROOT_DIR . '/vendor/autoload.php';
 }
 
+define('WIZARD_EMBEDDED', true);
+
 /* ───────────────────────────────────────────────────────────── */
 /* 2. CABECERAS SEGURAS                                          */
 /* ───────────────────────────────────────────────────────────── */
@@ -134,7 +136,6 @@ dbg("✔ Vista embebida: {$viewPath}");
 /* ───────────────────────────────────────────────────────────── */
 /* 10. INCLUIR LA VISTA EMBEBIDA                                 */
 /* ───────────────────────────────────────────────────────────── */
-define('WIZARD_EMBEDDED', true);
 include $viewPath;
 
 /* ───────────────────────────────────────────────────────────── */

--- a/src/Utils/Session.php
+++ b/src/Utils/Session.php
@@ -104,6 +104,8 @@ if (!function_exists('sendSecurityHeaders')) {
             return; // Evita warnings y roturas de DOM
         }
 
+        $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;
+
         header('Content-Type: ' . $contentType);
         header('Strict-Transport-Security: max-age=' . $hstsMaxAge . '; includeSubDomains; preload');
         header('X-Frame-Options: DENY');
@@ -113,6 +115,12 @@ if (!function_exists('sendSecurityHeaders')) {
         }
         header('Referrer-Policy: no-referrer');
         header('Permissions-Policy: geolocation=(), microphone=()');
+
+        if (!$embedded) {
+            header('X-Permitted-Cross-Domain-Policies: none');
+            header('X-DNS-Prefetch-Control: off');
+            header('Expect-CT: max-age=86400, enforce');
+        }
 
         if ($csp) {
             header('Content-Security-Policy: ' . $csp);

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -78,6 +78,9 @@ if (!$embedded) {
     header('X-Frame-Options: DENY');
     header('X-Content-Type-Options: nosniff');
     header('Referrer-Policy: no-referrer');
+    header('X-Permitted-Cross-Domain-Policies: none');
+    header('X-DNS-Prefetch-Control: off');
+    header('Expect-CT: max-age=86400, enforce');
     header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
     header('Pragma: no-cache');
     header("Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' https://cdn.jsdelivr.net");


### PR DESCRIPTION
## Summary
- enhance security headers when not embedded
- apply new headers on step6 view
- move WIZARD_EMBEDDED definition earlier to skip headers for partial loads

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b69108510832c8f8eaa67240b9fbc