### PR TITLE
Enforce session ID regeneration after critical updates

### DIFF
--- a/api/restore_progress.php
+++ b/api/restore_progress.php
@@ -78,6 +78,7 @@ if ($progressRaw < 0 || $progressRaw > 6) {
 // (D) Fijar en sesión y devolver éxito
 // store the chosen step so wizard.php can resume correctly
 $_SESSION['wizard_progress'] = $progressRaw;
+session_regenerate_id(true);
 dbgLocal("wizard_progress restaurado a $progressRaw");
 echo json_encode([
     'success' => true,

--- a/includes/security.php
+++ b/includes/security.php
@@ -43,6 +43,7 @@ function generate_csrf_token(): string
     }
     if (empty($_SESSION['csrf_token'])) {
         $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        session_regenerate_id(true);
     }
     return $_SESSION['csrf_token'];
 }

--- a/public/handle-step.php
+++ b/public/handle-step.php
@@ -56,5 +56,6 @@ foreach ($_POST as $k => $v) {
 $next = StepperFlow::next($mode, $step);
 // Wizard progress counter is stored so the user cannot skip steps
 $_SESSION['wizard_progress'] = $next ?? $step;
+session_regenerate_id(true);
 
 echo json_encode(['success'=>true,'next'=>$next]);

--- a/src/Utils/Session.php
+++ b/src/Utils/Session.php
@@ -71,6 +71,7 @@ if (!function_exists('generateCsrfToken')) {
         startSecureSession();
         if (empty($_SESSION['csrf_token']) || strlen($_SESSION['csrf_token']) !== 64) {
             $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+            session_regenerate_id(true);
         }
         return $_SESSION['csrf_token'];
     }

--- a/step6.php
+++ b/step6.php
@@ -36,6 +36,7 @@ try {
 // Basic CSRF token
 if (!isset($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(16));
+    session_regenerate_id(true);
 }
 $csrf = $_SESSION['csrf_token'];
 

--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -104,6 +104,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST'
 // -------------------------------------------
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    session_regenerate_id(true);
 }
 $csrf = $_SESSION['csrf_token'];
 
@@ -137,10 +138,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['rate_limit'][$clientIp][] = time();
 
         // Avanzar paso
-        session_regenerate_id(true);
         $_SESSION['material_id']     = $mat;
         $_SESSION['thickness']       = (float)$thk;
         $_SESSION['wizard_progress'] = 1;  // Marcamos Paso 1 completado
+        session_regenerate_id(true);
         dbg("✅ Paso 1 completado: material={$mat}, thickness={$thk}");
         session_write_close();
 

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -74,6 +74,7 @@ $_SESSION['wizard_state'] = 'wizard'; // Asegurar estado
 // -------------------------------------------
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    session_regenerate_id(true);
 }
 $csrfToken = $_SESSION['csrf_token'];
 
@@ -160,10 +161,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // [H.5] Si no hay errores, guardar en sesión y avanzar
     if (empty($errors)) {
-        session_regenerate_id(true);
         $_SESSION['machining_type_id'] = $typeRaw;
         $_SESSION['strategy_id']       = $stratRaw;
         $_SESSION['wizard_progress']   = 2;
+        session_regenerate_id(true);
         dbg("✅ Paso 2 completado: type={$typeRaw}, strat={$stratRaw}");
         session_write_close();
         header('Location: step3.php');

--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -100,8 +100,8 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['tool_id'],$_POST['tool_
         else                  $tool=fetchTool($pdo,$tbl,'id',$id);
         if(!$tool)            $error="No se encontró la herramienta #{$id}.";
         else{
-            session_regenerate_id(true);
             $_SESSION['tool_id']=$id; $_SESSION['tool_table']=$tbl; $_SESSION['wizard_progress']=4;
+            session_regenerate_id(true);
         }
     }
 }
@@ -114,8 +114,8 @@ elseif($_SERVER['REQUEST_METHOD']==='GET' && isset($_GET['brand'],$_GET['code'])
         $tbl=$map[$brand]; $tool=fetchTool($pdo,$tbl,'code',$code);
         if(!$tool)         $error="No se encontró la fresa {$code}.";
         else{
-            session_regenerate_id(true);
             $_SESSION['tool_id']=(int)$tool['tool_id']; $_SESSION['tool_table']=$tbl; $_SESSION['wizard_progress']=4;
+            session_regenerate_id(true);
         }
     }
 }

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -36,6 +36,7 @@ header("Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-$n
 if (empty($_SESSION['wizard_state']) || $_SESSION['wizard_state'] !== 'wizard') {
     $_SESSION['wizard_state']    = 'wizard';
     $_SESSION['wizard_progress'] = 1;
+    session_regenerate_id(true);
 }
 
 // Si el usuario ya completó el Paso 1 (wizard_progress > 1),
@@ -62,6 +63,7 @@ require_once __DIR__ . '/../../../includes/db.php';
 // ──────────────── 5) Generar/verificar CSRF token ──────────────────
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    session_regenerate_id(true);
 }
 $csrfToken = $_SESSION['csrf_token'];
 
@@ -112,6 +114,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['tool_image_url'] = $imgUrl;
 
         $_SESSION['wizard_progress'] = 2; // Marcamos que ya completó Paso 1
+        session_regenerate_id(true);
         dbg('Paso 1 validado con éxito. tool_id=' . $toolId . ' tool_table=' . $toolTable);
 
         header('Location: step2.php');

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -74,6 +74,7 @@ $_SESSION['wizard_state'] = 'wizard';
  * ──────────────────────────────────────────────────── */
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    session_regenerate_id(true);
 }
 $csrfToken = $_SESSION['csrf_token'];
 
@@ -171,6 +172,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['machining_type_id'] = $mtId;
         $_SESSION['strategy_id']       = $stId;
         $_SESSION['wizard_progress']   = 3;
+        session_regenerate_id(true);
         header('Location: step4_select_material.php');
         exit;
     }

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -73,7 +73,10 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && count($_SESSION['rate_limit'][$client
 //
 // [F] CSRF-token
 //
-$_SESSION['csrf_token'] ??= bin2hex(random_bytes(32));
+if (!isset($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    session_regenerate_id(true);
+}
 $csrf = $_SESSION['csrf_token'];
 
 //
@@ -131,10 +134,10 @@ if ($_SERVER['REQUEST_METHOD']==='POST'){
 
     if(!$err){
         $_SESSION['rate_limit'][$clientIp][] = time();
-        session_regenerate_id(true);
         $_SESSION['material_id']=$mat;
         $_SESSION['thickness'] =(float)$thk;
         $_SESSION['wizard_progress']=4;
+        session_regenerate_id(true);
         header('Location:' . asset('views/steps/manual/step5.php')); exit;
     }
 }

--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -38,6 +38,7 @@ require_once __DIR__ . '/../../includes/debug.php';
 /* 3) CSRF token */
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    session_regenerate_id(true);
 }
 $csrfToken = $_SESSION['csrf_token'];
 
@@ -90,6 +91,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             'hp'              => $hp,
             'wizard_progress' => 5,
         ];
+        session_regenerate_id(true);
         session_write_close();
         header('Location: step6.php');
         exit;

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -124,6 +124,7 @@ $needsToken = empty($_SESSION['csrf_token']) ||
 if ($needsToken) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     $_SESSION['csrf_token_time'] = time();
+    session_regenerate_id(true);
 }
 $csrfToken = $_SESSION['csrf_token'];
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {


### PR DESCRIPTION
## Summary
- regenerate session ID when generating CSRF tokens
- move `session_regenerate_id(true)` after modifying `wizard_progress`
- update wizard steps and utilities accordingly

## Testing
- `php -dmemory_limit=-1 vendor/bin/phpunit` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6a07d20c832c98a48f73049466ec