### PR TITLE
Add AJAX header check and client header

### DIFF
--- a/ajax/step6_ajax_legacy_minimal.php
+++ b/ajax/step6_ajax_legacy_minimal.php
@@ -38,6 +38,15 @@ header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 // Iniciar sesión para CSRF
 session_start(); // ensures $_SESSION['csrf_token'] is available
 
+// Confirm AJAX header to avoid serving full HTML
+$isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+          $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest';
+if (!$isAjax) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Invalid request']);
+    exit;
+}
+
 function respond_json_error(string $msg, int $code = 400): never {
     http_response_code($code);
     echo json_encode(['success' => false, 'error' => $msg], JSON_UNESCAPED_UNICODE);

--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -228,7 +228,8 @@ window.initStep6 = function () {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-CSRF-Token': csrfToken
+          'X-CSRF-Token': csrfToken,
+          'X-Requested-With': 'XMLHttpRequest'
         },
         body: JSON.stringify(payload),
         cache: 'no-store',


### PR DESCRIPTION
## Summary
- detect XMLHttpRequest header in the step6 AJAX endpoint
- send `X-Requested-With` header from the step6 JS fetch call

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7026ed2c832c9745441caf922f7d