### PR TITLE
Wrap initStep6 in strict IIFE

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -8,9 +8,13 @@
 /* global Chart */
 
 // Mantiene la instancia del gráfico entre ejecuciones
-window.radarChartInstance = window.radarChartInstance || null;
+//
+(function (window, document) {
+  'use strict';
 
-window.initStep6 = function () {
+  window.radarChartInstance = window.radarChartInstance || null;
+
+  window.initStep6 = function () {
   const errBox = document.getElementById('errorMsg');
   const showFatal = msg => {
     if (errBox) {
@@ -289,4 +293,6 @@ window.initStep6 = function () {
     console.error('[step6] init error', e);
     showFatal(`JS: ${e.message}`);
   }
-};
+  };
+
+})(window, document);


### PR DESCRIPTION
## Summary
- wrap `initStep6` function body in a strict-mode IIFE

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0e1d227c832cbcf3c7718c61b618