### PR TITLE
Add DOM validation in initStep6

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -15,6 +15,14 @@
   window.radarChartInstance = window.radarChartInstance || null;
 
   window.initStep6 = function () {
+  const requiredIds = ['sliderFz','sliderVc','sliderAe','sliderPasadas','radarChart','errorMsg'];
+  const missing = requiredIds.filter(id => document.getElementById(id) === null);
+  if (missing.length > 0) {
+    console.error('[step6] Elementos DOM faltantes:', missing);
+    alert('Error crítico: faltan elementos de interfaz: ' + missing.join(', '));
+    return; // aborta initStep6 para que no intente operar sobre elementos nulos
+  }
+
   const errBox = document.getElementById('errorMsg');
   const showFatal = msg => {
     if (errBox) {


### PR DESCRIPTION
## Summary
- detect missing DOM elements on step 6 init to prevent null references

## Testing
- `composer test` *(fails: command not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0fa2a148832ca1025057dab8d19c