### PR TITLE
Add loading state to step6 recalculation

### DIFF
--- a/assets/css/components/_step6.css
+++ b/assets/css/components/_step6.css
@@ -11,6 +11,9 @@
 
 @import url('../settings/_variables.css');
 
+/* Contenedor principal */
+.step6 {position: relative;}
+
 /* =======================  Paleta y texto base  ====================== */
 
 /* =======================  Tarjetas genéricas  ======================= */
@@ -122,6 +125,8 @@
   visibility: hidden;
   background: rgb(0 0 0 / 50%);
 }
+.step6.loading .spinner-overlay {visibility: visible;}
+.step6.loading .slider-wrap {opacity: 0.5; pointer-events: none;}
 .step6 .spinner-overlay.show {visibility: visible;}
 
 .step6 .spinner-border {

--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -164,6 +164,13 @@
     slider.dataset.prevValue = '';
   }
 
+  // Deshabilita controles y muestra spinner
+  function setLoading(on) {
+    const container = document.querySelector('.step6');
+    container.classList.toggle('loading', !!on);
+    [sFz, sVc, sAe, sP].forEach(slider => slider.disabled = !!on);
+  }
+
   // 8. Pasadas slider / info
   const thickness = parseFloat(sP.dataset.thickness);
   function updatePasadasSlider() {
@@ -265,6 +272,7 @@
     };
 
     table(payload);
+    setLoading(true);
     try {
       const res = await fetch(`${BASE_URL}/ajax/step6_ajax_legacy_minimal.php`, {
         method: 'POST',
@@ -317,6 +325,8 @@
       }
       error('recalc error', e);
       showError(`Conexión fallida: ${e.message}`);
+    } finally {
+      setLoading(false);
     }
     log('return void');
     });

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -331,6 +331,11 @@ if (!file_exists($countUpLocal))
 <?php endif; ?>
 
 <div class="step6">
+  <div id="step6Spinner" class="spinner-overlay">
+    <div class="spinner-border" role="status">
+      <span class="visually-hidden">Cargando...</span>
+    </div>
+  </div>
 <div class="content-main">
   <div class="container py-4">
     <h2 class="step-title"><i data-feather="bar-chart-2"></i> Resultados</h2>


### PR DESCRIPTION
## Summary
- disable sliders and show spinner during recalculation
- display spinner overlay
- style loading state for step6

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5987dd94832ca44f727e0d4f5e5b