### PR TITLE
Update Step 6 layout and styles

### DIFF
--- a/assets/css/components/_step6.css
+++ b/assets/css/components/_step6.css
@@ -12,7 +12,10 @@
 @import url('../settings/_variables.css');
 
 /* Contenedor principal */
-.step6 {position: relative;}
+.step6 {
+  position: relative;
+  color: var(--text-color-sec);
+}
 
 /* =======================  Paleta y texto base  ====================== */
 
@@ -61,7 +64,14 @@
 .step6 .spec-list li span:last-child  {font-weight: 600;color: var(--accent-color);}
 
 /* Imagen vectorial */
-.step6 .vector-image {display: block;max-height: 280px;margin: 0 auto;object-fit: contain;}
+.step6 .vector-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  max-height: none;
+  margin: 0 auto;
+  object-fit: contain;
+}
 
 /* =========================  Grilla de tarjetas  ===================== */
 .step6 .cards-grid {

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -349,7 +349,7 @@ div class="content-main">
     <p class="step-desc">Ajustá los parámetros y revisá los datos de corte.</p>
   <!-- BLOQUE CENTRAL -->
   <div class="row gx-3 mb-4 cards-grid">
-    <div class="col-12 col-lg-4 mb-3 area-tool">
+    <div class="col-12 mb-3 area-tool">
       <div class="card h-100 shadow-sm">
         <div class="card-header text-center p-3">
           <span>#<?= $serialNumber ?> – <?= $toolCode ?></span>


### PR DESCRIPTION
## Summary
- lighten default text for step 6
- make main image card full width
- allow vector image to fill its container

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `./vendor/bin/phpunit --version` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c738a9e88832c935bf4d69cb71723