### PR TITLE
Refactor step6 css

### DIFF
--- a/assets/css/objects/step6.css
+++ b/assets/css/objects/step6.css
@@ -1,5 +1,164 @@
-.step6-error {
-  padding: 1rem;
-  color: #fff;
-  background: #900;
+/* File: assets/css/objects/step6.css (refactor 2025-06-25) */
+@import url('../settings/_variables.css');
+
+:root {
+  --step6-accent: var(--accent-color);
+  --step6-bg-card: var(--bg-card);
+  --step6-border: var(--border-color);
+  --step6-radius: var(--border-radius-xxl);
 }
+
+[data-theme='dark'] {
+  --step6-accent: #7fdcff;
+  --step6-bg-card: #161b22;
+  --step6-border: #2c2f33;
+  --step6-radius: var(--border-radius-xxl);
+}
+
+/* STEP6 layout */
+.cards-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(0.75rem, 2vw, 1rem);
+  align-items: flex-start;
+}
+
+@media (min-width: 768px) {
+  /* STEP6 layout */
+  .cards-grid {grid-template-columns: repeat(2, 1fr);}
+}
+@media (min-width: 992px) {
+  /* STEP6 layout */
+  .cards-grid {grid-template-columns: repeat(3, 1fr);}
+}
+
+/* STEP6 card */
+.cards-grid .card {
+  border: 1px solid var(--step6-border);
+  border-radius: var(--step6-radius);
+  background: var(--step6-bg-card);
+}
+.card-header {
+  font-weight: 600;
+  text-align: center;
+  color: var(--step6-accent);
+  background: var(--bg-header);
+}
+.card.h-100 {display: flex; flex-direction: column;}
+
+/* STEP6 tool */
+.tool-image {
+  display: block;
+  margin: clamp(0.5rem, 2vw, 0.75rem) auto;
+  max-height: 120px;
+  object-fit: contain;
+}
+.tool-name {margin-top: 0.5rem; font-size: clamp(1rem, 1.2vw, 1.1rem); font-weight: 600;}
+.tool-type {font-size: clamp(0.9rem, 1vw, 1rem); color: var(--text-color-sec);}
+
+/* STEP6 specs */
+.spec-list {margin: 0; padding-left: 0; list-style: disc inside;}
+.spec-list li {display: flex; justify-content: space-between; margin-bottom: 0.35rem;}
+.spec-list li span:first-child {color: var(--text-color);}
+.spec-list li span:last-child {font-weight: 600; color: var(--step6-accent);}
+.vector-image {display: block; width: 100%; height: 100%; object-fit: contain;}
+
+/* STEP6 sliders */
+.slider-wrap {position: relative;}
+.slider-bubble {
+  position: absolute;
+  top: -1.6rem;
+  left: calc(var(--val) * 1%);
+  transform: translateX(-50%);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: var(--bg-body);
+  background: var(--step6-accent);
+}
+@keyframes shake {0%,100%{transform:translateX(-50%) translateY(0);}50%{transform:translateX(-50%) translateY(-2px);}}
+.slider-wrap input:active + .slider-bubble {animation: shake 0.3s;}
+input.form-range:focus-visible::-webkit-slider-thumb {box-shadow: 0 0 0 3px rgb(79 195 247 / 40%);}
+input.form-range:focus-visible::-moz-range-thumb {box-shadow: 0 0 0 3px rgb(79 195 247 / 40%);} 
+
+/* STEP6 results */
+.result-box {
+  flex: 1;
+  min-width: 80px;
+  margin: 0.3rem;
+  padding: 0.5rem;
+  border: 1px solid var(--step6-border);
+  border-radius: 0.25rem;
+  text-align: center;
+}
+.param-label {font-size: 0.75rem; color: var(--text-color-sec);}
+.fw-bold {color: var(--step6-accent);}
+#radarChart {max-width: 100% !important;}
+
+/* STEP6 config */
+.config-card-static {padding: clamp(0.75rem, 2vw, 0.8rem);}
+.config-section-title {margin-bottom: 0.25rem; font-weight: 600; color: var(--text-color);}
+.config-item {display: flex; justify-content: space-between; margin: 0.25rem 0;}
+.label-static {color: var(--text-color);}
+.value-static {font-weight: 600; color: var(--step6-accent);}
+.section-divider {margin: 0.5rem 0; border-bottom: 1px solid rgb(255 255 255 / 10%);}
+
+/* STEP6 notes */
+.notes-card {padding: clamp(0.75rem, 2vw, 0.8rem);}
+.notes-list {margin: 0; padding: 0; list-style: none;}
+.notes-list li {display: flex; gap: 0.5rem; align-items: flex-start; padding: 0.25rem 0;}
+.notes-list li i {margin-top: 0.2rem; font-size: 1rem; color: var(--step6-accent);}
+.notes-list li div {font-size: 0.9rem; color: var(--text-color);}
+
+.text-secondary {color: var(--text-color-sec) !important;}
+
+/* STEP6 spinner */
+.spinner-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--step6-radius);
+  background: rgba(0,0,0,0.5);
+  visibility: hidden;
+}
+.loading .spinner-overlay,
+.spinner-overlay.show {visibility: visible;}
+.spinner-border {
+  width: var(--spinner-size);
+  height: var(--spinner-size);
+  border: 4px solid var(--step6-accent);
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {to{transform: rotate(360deg);}}
+
+/* STEP6 debug */
+.debug-panel {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9999;
+  max-height: 150px;
+  padding: 0.5rem;
+  overflow-y: auto;
+  display: none;
+  font-family: Consolas, monospace;
+  font-size: 0.85rem;
+  color: #0f0;
+  background: rgb(0 0 0 / 80%);
+}
+.debug-panel.show {display: block;}
+
+/* STEP6 quick-test */
+/*
+// Resalta en rojo cualquier elemento con overflow horizontal
+// (útil en DevTools)
+document.querySelectorAll('*').forEach(el=>{
+  if (el.scrollWidth > el.clientWidth) el.style.outline='2px solid red';
+});
+*/


### PR DESCRIPTION
## Summary
- refactor step 6 CSS into a single file
- add responsive grid and color variables
- include dark mode variants and spinner overlay fixes

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c75ec2394832c98e4c0c1b3ec6a31