### PR TITLE
Rotate vertical thumbnails

### DIFF
--- a/assets/js/step1_manual_lazy_loader.js
+++ b/assets/js/step1_manual_lazy_loader.js
@@ -72,6 +72,8 @@ export async function loadPage() {
           <td>${t.flute_count ?? ""}</td>
           <td>${t.tool_type ?? ""}</td>`;
         tbody.appendChild(tr);
+        const img = tr.querySelector('img.thumb');
+        if (img && window.checkThumbOrientation) window.checkThumbOrientation(img);
       });
     }
     hasMore = data.hasMore;

--- a/assets/js/step1_manual_tool_browser.js
+++ b/assets/js/step1_manual_tool_browser.js
@@ -140,6 +140,8 @@
           <td class="text-truncate" style="max-width:200px">${t.name}</td>
           <td>${t.diameter_mm}</td><td>${t.flute_count||'-'}</td><td>${t.tool_type}</td>
         </tr>`);
+        const img = tableBody.lastElementChild?.querySelector('img.thumb');
+        if (img && window.checkThumbOrientation) window.checkThumbOrientation(img);
     });
 
     /* hook de selección */

--- a/assets/js/thumb_orientation.js
+++ b/assets/js/thumb_orientation.js
@@ -1,0 +1,19 @@
+(() => {
+  window.checkThumbOrientation = function (img) {
+    if (!img) return;
+    const apply = () => {
+      if (img.naturalHeight > img.naturalWidth) {
+        img.classList.add('portrait');
+      }
+    };
+    if (img.complete) {
+      apply();
+    } else {
+      img.addEventListener('load', apply, { once: true });
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('img.thumb').forEach(window.checkThumbOrientation);
+  });
+})();

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -248,6 +248,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <!-- ─────────────── Scripts ──────────────────────────────────────── -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
+  <!-- Detectar orientación de miniaturas -->
+  <script src="<?= asset('assets/js/thumb_orientation.js') ?>"></script>
+
   <!-- Script principal del paso (se encarga de rellenar la tabla y habilitar radios) -->
   <script src="<?= asset('assets/js/step1_manual_tool_browser.js') ?>"
           onload="window._TOOL_BROWSER_LOADED=true"


### PR DESCRIPTION
## Summary
- check orientation of thumb images and add `.portrait` class if needed
- use orientation checker on new rows
- include orientation script in manual step 1

## Testing
- `npm run lint:css --silent` *(fails: `stylelint` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3841e8f4832c9fb55d339a7d08a9