### PR TITLE
Fix orientation of vertical tool images in step 1

### DIFF
--- a/assets/js/step1_manual_lazy_loader.js
+++ b/assets/js/step1_manual_lazy_loader.js
@@ -20,6 +20,23 @@ const materialId = parseInt(
 const strategyMeta = document.querySelector('meta[name="strategy-id"]');
 const strategyId = strategyMeta ? parseInt(strategyMeta.content, 10) : null;
 
+// --- rotación de miniaturas verticales ----------------------------------
+function marcarRetrato(img) {
+  if (img.naturalHeight > img.naturalWidth) {
+    img.classList.add('portrait');
+  }
+}
+
+function ajustarMiniaturas(scope = document) {
+  scope.querySelectorAll('img.thumb').forEach((img) => {
+    if (img.complete) {
+      marcarRetrato(img);
+    } else {
+      img.addEventListener('load', () => marcarRetrato(img), { once: true });
+    }
+  });
+}
+
 console.log('Sentinel:', sentinel);
 
 const scrollContainer = document.querySelector('.list-scroll-container');
@@ -73,6 +90,7 @@ export async function loadPage() {
           <td>${t.tool_type ?? ""}</td>`;
         tbody.appendChild(tr);
       });
+      ajustarMiniaturas(tbody);
     }
     hasMore = data.hasMore;
     if (hasMore) {

--- a/assets/js/step1_manual_tool_browser.js
+++ b/assets/js/step1_manual_tool_browser.js
@@ -35,6 +35,23 @@
   let toolsData   = [];
   let currentSort = { col:null, dir:null };
 
+  /* -------- rotación de imágenes verticales ----------------------- */
+  function marcarRetrato(img){
+    if(img.naturalHeight > img.naturalWidth){
+      img.classList.add('portrait');
+    }
+  }
+
+  function ajustarMiniaturas(scope=document){
+    scope.querySelectorAll('img.thumb').forEach(img=>{
+      if(img.complete){
+        marcarRetrato(img);
+      } else {
+        img.addEventListener('load',()=>marcarRetrato(img),{once:true});
+      }
+    });
+  }
+
   /* ========== CARGAR FACETAS ====================================== */
   fetch(`${BASE_URL}/public/tools_facets.php`,{cache:'no-store'})
     .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
@@ -153,6 +170,7 @@
       };
     });
     ordenarIconos();
+    ajustarMiniaturas(tableBody);
   }
 
   /* ========== ORDENAMIENTO CLIENT-SIDE ============================ */


### PR DESCRIPTION
## Summary
- detect portrait thumbnails in Step 1 manual scripts
- rotate vertical images using existing `.portrait` CSS

## Testing
- `vendor/bin/phpunit`
- `npm run lint:css` *(fails: declaration-empty-line-before and other stylelint issues)*

------
https://chatgpt.com/codex/tasks/task_e_685d3841e8f4832c9fb55d339a7d08a9