### PR TITLE
Add collapsible filter bar to manual step 1

### DIFF
--- a/assets/css/components/_step1.css
+++ b/assets/css/components/_step1.css
@@ -160,3 +160,53 @@ h2.fw-bold {           /* Título principal de la página */
   width: auto;
   height: 80px;
 }
+
+/* ──────────────── Barra de filtros plegable (Paso 1 Manual) ─────────────── */
+.filter-wrapper {
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 1100;
+}
+
+.filter-bar {
+  width: 260px;
+  height: 100%;
+  overflow-y: auto;
+  background: #0d1624;
+  color: #e5e7eb;
+  transform: translateX(-100%);
+  transition: transform 0.35s;
+}
+
+.filter-toggle {
+  position: absolute;
+  left: 100%;
+  top: 1rem;
+  width: 40px;
+  height: 40px;
+  border: 0;
+  border-radius: 50%;
+  background: var(--step6-accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.filter-toggle i {
+  transition: transform 0.35s;
+}
+
+.filter-wrapper.open .filter-bar {
+  transform: translateX(0);
+}
+
+.filter-wrapper.open .filter-toggle i {
+  transform: rotate(180deg);
+}
+
+@media (max-width: 767.98px) {
+  .filter-bar {
+    width: 80vw;
+  }
+}

--- a/views/steps/manual/step1.php
+++ b/views/steps/manual/step1.php
@@ -179,9 +179,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
              onerror="this.remove()">
       </div>
 
-      <div class="row">
-        <!-- Filtros -->
-        <aside class="col-md-3 sidebar">
+      <div class="filter-wrapper open">
+        <button class="filter-toggle" aria-label="Mostrar/ocultar filtros">
+          <i data-feather="chevron-left"></i>
+        </button>
+        <aside class="filter-bar">
           <div class="card h-100 shadow-sm">
             <div class="card-header bg-primary text-white py-2">
               <i class="bi bi-funnel"></i> Filtros
@@ -192,9 +194,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </div>
           </div>
         </aside>
+      </div>
 
+      <div class="row">
         <!-- Tabla -->
-        <main class="col-md-9">
+        <main class="col-md-12">
           <div class="input-group mb-2">
             <span class="input-group-text">
               <i class="bi bi-search"></i>
@@ -254,6 +258,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           onerror="console.error('❌ step1_manual_tool_browser.js no cargó');">
   </script>
   <script type="module" src="<?= asset('assets/js/step1_manual_lazy_loader.js') ?>"></script>
+
+  <script nonce="<?= $nonce ?>">
+    document.querySelector('.filter-toggle')?.addEventListener('click', () => {
+      const wrap = document.querySelector('.filter-wrapper');
+      if (!wrap) return;
+      wrap.classList.toggle('open');
+      const icon = document.querySelector('.filter-toggle i');
+      const isOpen = wrap.classList.contains('open');
+      icon?.setAttribute('data-feather', isOpen ? 'chevron-left' : 'chevron-right');
+      if (window.feather && typeof feather.replace === 'function') {
+        feather.replace();
+      }
+    });
+  </script>
 
   <script type="module" nonce="<?= $nonce ?>">
       import { initToolTable } from '<?= asset('assets/js/step1_manual_table_hook.js') ?>';


### PR DESCRIPTION
## Summary
- add collapsible filter sidebar in manual step 1
- style new filter wrapper and button
- toggle icon and sidebar visibility with JS

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d38a3def0832c8302b23063537da8