### PR TITLE
Add Next button for auto step3

### DIFF
--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -200,14 +200,17 @@ try {
     <!-- ↓ Aquí se pintarán dinámicamente las “fresa-card” por JS ↓ -->
   </div>
 
-  <!-- 7.3) Formulario oculto que se usará al pulsar “Seleccionar” -->
-  <form id="selectForm" method="post" action="" style="display:none;">
+  <!-- 7.3) Formulario que almacenará la selección -->
+  <form id="selectForm" method="post" action="">
     <input type="hidden" name="step" value="3">
     <input type="hidden" id="tool_id"    name="tool_id"    value="">
     <input type="hidden" id="tool_table" name="tool_table" value="">
+    <div id="next-button-container" class="text-start mt-4" style="display:none;">
+      <button type="submit" id="btn-next" class="btn btn-primary btn-lg">
+        Siguiente <i data-feather="arrow-right" class="ms-1"></i>
+      </button>
+    </div>
   </form>
-
-  <!-- Botón "Siguiente" removido -->
 
   <!-- 7.4) Consola interna de debugging -->
 
@@ -246,6 +249,8 @@ try {
     const selectForm   = document.getElementById('selectForm');
     const inputToolId  = document.getElementById('tool_id');
     const inputToolTbl = document.getElementById('tool_table');
+    const nextContainer= document.getElementById('next-button-container');
+    const nextBtn      = document.getElementById('btn-next');
 
     let allTools = [];     // Aquí se guardará el array de fresas recibido
     let diameters = [];    // Diámetros únicos (array de strings con 3 decimales)
@@ -309,6 +314,7 @@ try {
      */
     function renderTools() {
       container.innerHTML = ''; // Limpiamos contenedor
+      nextContainer.style.display = 'none';
 
       if (allTools.length === 0) {
         container.innerHTML = `<div class="alert alert-warning">No se encontraron herramientas compatibles.</div>`;
@@ -393,7 +399,8 @@ try {
     }
 
     /**
-     * 5) Agrega listener a cada botón “Seleccionar” para enviar el formulario.
+     * 5) Agrega listener a cada botón “Seleccionar”.
+     *    Guarda la herramienta y muestra el botón "Siguiente".
      */
     function attachCardListeners() {
       document.querySelectorAll('.btn-select').forEach(btn => {
@@ -403,7 +410,7 @@ try {
           dbg('► [step3.js] Seleccionada herramienta → table=', tbl, 'tool_id=', id);
           inputToolId.value  = id;
           inputToolTbl.value = tbl;
-          selectForm.requestSubmit();
+          nextContainer.style.display = 'block';
         });
       });
     }


### PR DESCRIPTION
## Summary
- add blue `Siguiente` button on automatic step 3
- show the button when a tool is chosen

## Testing
- `npm install`
- `npm run lint:css` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_685d3ad09b9c832c9351bf372b469f57