### PR TITLE
Fix grey heading on auto tool step

### DIFF
--- a/assets/css/components/step3_auto_tool_recommendation.css
+++ b/assets/css/components/step3_auto_tool_recommendation.css
@@ -13,7 +13,7 @@
 
 h2 {
   margin-bottom: 1.5rem;
-  color: var(--text-color-muted);
+  color: #fff;
 }
 
 .form-label {

--- a/views/steps/auto/step3_auto_lazy_browser.php
+++ b/views/steps/auto/step3_auto_lazy_browser.php
@@ -41,7 +41,7 @@ $thickness  = $_SESSION['thickness']  ?? null;
 </head>
 <body>
   <main class="container py-4">
-    <h2>Herramientas compatibles</h2>
+    <h2 class="step-title"><i data-feather="tool"></i> Herramientas compatibles</h2>
     <div class="mb-3">
       <label for="diaFilter" class="form-label">Filtrar por diámetro</label>
       <select id="diaFilter" class="form-select">


### PR DESCRIPTION
## Summary
- show the Step 3 automatic heading using the standard white style
- make the heading text color white in the step3 auto stylesheet

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3adb8c80832c82d6e8af900d49da