### PR TITLE
Fix Step 6 initialization

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -819,6 +819,21 @@ safeScript('assets/js/step6.js');
 ?>
 
 <script>
+  // Inicializar paso 6 cuando el DOM y step6.js estén listos
+  document.addEventListener('DOMContentLoaded', function () {
+    try {
+      if (typeof window.initStep6 === 'function') {
+        window.initStep6();
+      } else {
+        console.error('initStep6 no definido');
+      }
+    } catch (e) {
+      console.error('Error en initStep6', e);
+    }
+  });
+</script>
+
+<script>
 /*-- Feather.replace() seguro: reintenta 10× cada 120 ms --*/
 (function waitFeather(r = 10) {
   if (window.feather && typeof feather.replace === 'function') {


### PR DESCRIPTION
## Summary
- auto run `initStep6()` when Step 6 page loads

## Testing
- `npm run lint:css` *(fails: stylelint not found or lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d3e62d208832c90fb3c8874b8dbad