### PR TITLE
Fix Step6 AJAX URL

### DIFF
--- a/README_STEP6_AJAX.md
+++ b/README_STEP6_AJAX.md
@@ -3,3 +3,4 @@
 - Los registros de depuración se activan definiendo `window.DEBUG = true` antes de cargar `step6.js`.
 - Al cerrar la pestaña se limpian todas las entradas `step6:*` de `sessionStorage`.
 - Los fallos de red o abortos de la petición se reintentan una vez antes de mostrar el mensaje de error.
+- La URL del endpoint puede ajustarse definiendo `window.step6AjaxUrl` antes de cargar `step6.js`.

--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -58,7 +58,8 @@
     var ctrl = new AbortController();
     var to = setTimeout(function () { ctrl.abort(); }, 8000);
     var t0 = performance.now();
-    return fetch('ajax/step6_ajax_legacy_minimal.php', {
+    var url = w.step6AjaxUrl || 'ajax/step6_ajax_legacy_minimal.php';
+    return fetch(url, {
       method: 'POST',
       body: body,
       headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': w.step6Csrf, 'Accept': '*/*' },

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -758,6 +758,7 @@ foreach ($styles as [$local, $cdn]) {
         JSON_HEX_APOS | JSON_HEX_QUOT
   ) ?>;
   window.step6Csrf   = <?= json_encode($csrfToken, JSON_HEX_TAG) ?>;
+  window.step6AjaxUrl = <?= json_encode(asset('ajax/step6_ajax_legacy_minimal.php'), JSON_HEX_TAG) ?>;
 </script>
 
 <?php if (!$embedded): ?>


### PR DESCRIPTION
## Summary
- allow overriding step6 AJAX URL through a new `step6AjaxUrl` global
- document new variable

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685d59e435bc832c9780f22c58d6e327