### PR TITLE
Add console logs for step6 load status

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -1,6 +1,7 @@
 /* STEP6-AJAX */
 (function (w, d) {
   'use strict';
+  console.info('[step6] JS cargado');
   var DEBUG = w.DEBUG === true;
   var ttl = 600000; // 10 min
   function dbg() { if (DEBUG) console.log.apply(console, arguments); }
@@ -89,9 +90,11 @@
       if (!j.success) throw new Error(j.error || 'Error');
       sessionStorage.setItem(key, JSON.stringify({ ts: Date.now(), data: j.data }));
       paint(j.data);
+      console.info('[step6] AJAX cargado correctamente');
     }).catch(function (e) {
       if (retry && (e.name === 'AbortError' || e.message === 'Failed to fetch')) return fetchData(body, key, false);
       showErr(e.message);
+      console.error('[step6] Error AJAX:', e);
     }).finally(function () { setLoading(false); dbg('ms', (performance.now() - t0).toFixed(1)); });
   }
   function recalc() {
@@ -117,4 +120,5 @@
       recalc();
     } catch (e) { showErr(e.message); }
   };
+  console.info('[step6] initStep6 registrado');
 })(window, document);

--- a/assets/js/step6.module.js
+++ b/assets/js/step6.module.js
@@ -1,6 +1,8 @@
 /* STEP6-AJAX */
 import { debounce } from './utils.js';
 
+console.info('[step6] JS cargado (module)');
+
 const w = window;
 const d = document;
 const DEBUG = w.DEBUG === true;
@@ -109,10 +111,12 @@ function fetchData(body, key, retry) {
     if (!j.success) throw new Error(j.error || 'Error');
     sessionStorage.setItem(key, JSON.stringify({ ts: Date.now(), data: j.data }));
     paint(j.data);
+    console.info('[step6] AJAX cargado correctamente');
   }).catch(e => {
     if (retry && (e.name === 'AbortError' || e.message === 'Failed to fetch'))
       return fetchData(body, key, false);
     showErr(e.message);
+    console.error('[step6] Error AJAX:', e);
   }).finally(() => {
     setLoading(false);
     dbg('ms', (performance.now() - t0).toFixed(1));
@@ -140,3 +144,4 @@ export function init() {
   } catch (e) { showErr(e.message); }
 }
 window.step6 = { init };
+console.info('[step6] init() registrado');


### PR DESCRIPTION
## Summary
- log when step6 JS loads in both classic and module versions
- log AJAX success or failure in step6 scripts
- log when init functions are registered

## Testing
- `composer test` *(fails: `composer` not found)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685da3b5e548832c8a838b08bef94d3c