### PR TITLE
Fix CSRF token usage on step 6

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -7,6 +7,7 @@
   function dbg() { if (DEBUG) console.log.apply(console, arguments); }
   function grp(t, fn) { if (!DEBUG) return fn(); console.group(t); try { return fn(); } finally { console.groupEnd(); } }
   function q(id) { return d.getElementById(id); }
+  var csrfToken = w.step6Csrf || (d.querySelector('meta[name="csrf-token"]') && d.querySelector('meta[name="csrf-token"]').content) || '';
 
   var step = d.querySelector('.step6');
   var errBox = q('errorMsg');
@@ -77,7 +78,7 @@
     return fetch(url, {
       method: 'POST',
       body: body,
-      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': w.step6Csrf, 'Accept': '*/*' },
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken, 'Accept': '*/*' },
       credentials: 'same-origin',
       cache: 'no-store',
       signal: ctrl.signal

--- a/assets/js/step6.module.js
+++ b/assets/js/step6.module.js
@@ -10,6 +10,7 @@ const ttl = 600000; // 10 min
 const dbg = (...m) => { if (DEBUG) console.log(...m); };
 const grp = (t, fn) => { if (!DEBUG) return fn(); console.group(t); try { return fn(); } finally { console.groupEnd(); } };
 const q = (id) => d.getElementById(id);
+const csrfToken = w.step6Csrf || d.querySelector('meta[name="csrf-token"]')?.content || '';
 
 const step = d.querySelector('.step6');
 const errBox = q('errorMsg');
@@ -98,7 +99,7 @@ function fetchData(body, key, retry) {
   return fetch(url, {
     method: 'POST',
     body,
-    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': w.step6Csrf, 'Accept': '*/*' },
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken, 'Accept': '*/*' },
     credentials: 'same-origin',
     cache: 'no-store',
     signal: ctrl.signal

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -290,6 +290,7 @@ if (!file_exists($countUpLocal))
 <meta charset="utf-8">
 <title>Paso 5 – Configurá tu router</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="csrf-token" content="<?= htmlspecialchars($csrfToken, ENT_QUOTES) ?>">
 <?php
 /* ─── Helper: <link> seguro ───────────────────────────────────────────── */
 function safeStyle(string $local, string $cdn = ''): void


### PR DESCRIPTION
## Summary
- expose CSRF token via meta tag in `step6.php`
- fallback to meta token in `step6.js` and `step6.module.js`

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da86f364c832cac9424d81f0d760f