### PR TITLE
Fix button color on auto step 4

### DIFF
--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -150,6 +150,7 @@ if($tool){
       'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css',
       'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css',
       'assets/css/components/_step2.css',
+      'assets/css/components/_button.css',
       'assets/css/objects/step-common.css',
     ];
     $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;


### PR DESCRIPTION
## Summary
- include `_button.css` in auto step 4 so the primary button matches other steps

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da839e038832cafc0bef3425ccd4e