### PR TITLE
Fix auto step3 next button style

### DIFF
--- a/views/steps/auto/step3.php
+++ b/views/steps/auto/step3.php
@@ -168,6 +168,7 @@ try {
     $styles = [
       'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css',
       'assets/css/components/step3_auto_tool_recommendation.css',
+      'assets/css/components/_button.css',
       'assets/css/objects/step-common.css',
     ];
     $embedded = defined('WIZARD_EMBEDDED') && WIZARD_EMBEDDED;


### PR DESCRIPTION
## Summary
- load `_button.css` in auto step3

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddb854ee4832c81faed70fc4214b4