### PR TITLE
Fix step6 ajax base URL fallback

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -74,7 +74,9 @@
     var ctrl = new AbortController();
     var to = setTimeout(function () { ctrl.abort(); }, 8000);
     var t0 = performance.now();
-    var url = w.step6AjaxUrl || 'ajax/step6_ajax_legacy_minimal.php';
+    var url = w.step6AjaxUrl ||
+              (w.BASE_URL ? w.BASE_URL + '/ajax/step6_ajax_legacy_minimal.php'
+                          : 'ajax/step6_ajax_legacy_minimal.php');
     return fetch(url, {
       method: 'POST',
       body: body,

--- a/assets/js/step6.module.js
+++ b/assets/js/step6.module.js
@@ -95,7 +95,9 @@ function fetchData(body, key, retry) {
   const ctrl = new AbortController();
   const to = setTimeout(() => { ctrl.abort(); }, 8000);
   const t0 = performance.now();
-  const url = w.step6AjaxUrl || 'ajax/step6_ajax_legacy_minimal.php';
+  const url = w.step6AjaxUrl ||
+              (w.BASE_URL ? `${w.BASE_URL}/ajax/step6_ajax_legacy_minimal.php`
+                          : 'ajax/step6_ajax_legacy_minimal.php');
   return fetch(url, {
     method: 'POST',
     body,


### PR DESCRIPTION
## Summary
- add `BASE_URL` fallback to default AJAX endpoint in step6 scripts

## Testing
- `composer test`
- `npx eslint assets/js/step6.js assets/js/step6.module.js` *(fails: unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_685ddfb82ff8832cae2018c417983191