### PR TITLE
Fix legacy view asset paths

### DIFF
--- a/wizard-stepper_Backup/views/layout_wizard.php
+++ b/wizard-stepper_Backup/views/layout_wizard.php
@@ -8,7 +8,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Wizard CNC</title>
-  <link rel="stylesheet" href="assets/css/wizard.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
 </head>
 <body>
 
@@ -40,10 +40,10 @@
   <pre id="debug" class="debug-box"></pre>
 
   <!-- Scripts -->
-  <script src="assets/js/stepper.js" defer></script>
-  <script src="assets/js/dashboard.js" defer></script>
-<link rel="stylesheet" href="assets/css/wizard.css">
-<link rel="stylesheet" href="assets/css/step6.css"><!-- <---- AGREGALO ACÁ -->
+  <script src="<?= asset('assets/js/stepper.js') ?>" defer></script>
+  <script src="<?= asset('assets/js/dashboard.js') ?>" defer></script>
+<link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
+<link rel="stylesheet" href="<?= asset('assets/css/step6.css') ?>"><!-- <---- AGREGALO ACÁ -->
 
 </body>
 </html>

--- a/wizard-stepper_Backup/views/steps/manual/step2.php
+++ b/wizard-stepper_Backup/views/steps/manual/step2.php
@@ -115,7 +115,7 @@ if ($tool) {
 ?>
 <link rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-<link rel="stylesheet" href="assets/css/step2_manual.css">
+<link rel="stylesheet" href="<?= asset('assets/css/step2_manual.css') ?>">
 
 <main class="wizard-body shadow-lg mt-4">
   <h2 class="text-info"><i class="bi bi-tools"></i> Confirmar herramienta</h2>

--- a/wizard-stepper_Backup/views/welcome.php
+++ b/wizard-stepper_Backup/views/welcome.php
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <title>Bienvenido</title>
-  <link rel="stylesheet" href="assets/css/wizard.css">
+  <link rel="stylesheet" href="<?= asset('assets/css/wizard.css') ?>">
 </head>
 <body class="center">
   <h1>🛠️ Wizard CNC</h1>
   <p>Asistente para configurar tu herramienta de corte.</p>
   <button id="btn-start" class="btn btn-primary">Iniciar</button>
-  <script src="assets/js/main.js"></script>
+  <script src="<?= asset('assets/js/main.js') ?>"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update backup views to use `asset()` helper

## Testing
- `vendor/bin/phpunit`
- `npm run lint:css` *(fails: many stylelint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685df5468938832cb0eda30755fc4049