### PR TITLE
Refactor Step 6 to dynamic ES module

### DIFF
--- a/ajax/step6_ajax_legacy_minimal.php
+++ b/ajax/step6_ajax_legacy_minimal.php
@@ -2,7 +2,7 @@
 /**
  *  Paso 6 – AJAX • Re-cálculo de parámetros
  *  -------------------------------------------------------------------------
- *  ▸ Endpoint exclusivo para peticiones `fetch()` en assets/js/step6.module.js
+ *  ▸ Endpoint exclusivo para peticiones `fetch()` en assets/js/step6.js
  *  ▸ Entrada  : JSON            (ver $requiredKeys)
  *  ▸ Salida   : { success, data, error? }
  *  ▸ Seguridad:  • Sólo XMLHttpRequest

--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -1,4 +1,4 @@
-/*  assets/js/step6.module.js
+/*  assets/js/step6.js
    -------------------------------------------------------------
    Paso 6 – Módulo ESM unificado
    · Exporta   init()            → permite import dinámico

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -820,7 +820,17 @@ safeScript(
 ?>
 <!-- views/steps/step6.php  ── al final, justo antes de </body> -->
 
-  <script type="module" src="<?= asset('assets/js/step6.js') ?>"></script>
+  <script type="module">
+    (async () => {
+      try {
+        const { init } = await import("<?= asset('assets/js/step6.js') ?>");
+        console.info('%c[step6] módulo cargado OK', 'color:#4fc3f7;font-weight:700');
+        init();
+      } catch (e) {
+        console.error('[step6] módulo no encontrado', e);
+      }
+    })();
+  </script>
 
 <script>
 /*-- Feather.replace() seguro: reintenta 10× cada 120 ms --*/

--- a/views/wizard_layout.php
+++ b/views/wizard_layout.php
@@ -108,7 +108,6 @@ declare(strict_types=1);
   <!-- SCRIPT GLOBAL DEL STEPPER -->
   <script src="<?= asset('assets/js/wizard_stepper.js') ?>" defer></script>
   <script src="<?= asset('assets/js/dashboard.js') ?>" defer></script>
-  <script src="<?= asset('assets/js/step6.js') ?>" defer></script>
 
   <!-- FOOTER CORPORATIVO (NO INTERFIERE CON EL MAIN) -->
   <footer class="footer-schneider text-white mt-5">


### PR DESCRIPTION
## Summary
- remove outdated script in layout
- load Step 6 via dynamic import
- update module header comment
- update AJAX reference to new module name

## Testing
- `composer test` *(fails: composer not found)*
- `vendor/bin/phpunit --version` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e06225114832c91e4623da6e91097