### PR TITLE
Ensure step6 waits for DOM

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -6,6 +6,17 @@
 ----------------------------------------------------------------*/
 
 export function init () {
+  const ready = document.getElementById('sliderVc');
+  if (!ready) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init, { once: true });
+      console.info('[step6] esperando DOMContentLoaded');
+    } else {
+      console.warn('[step6] #sliderVc no encontrado');
+    }
+    return;
+  }
+
   /* ---------- 1. Variables globales inyectadas por PHP ---------- */
   const {
     diameter : D, flute_count : Z,
@@ -20,9 +31,17 @@ export function init () {
   /* ---------------- 2. DOM helpers ---------------- */
   const q = id => document.getElementById(id);
 
-  const sFz = q('sliderFz'),  sVc = q('sliderVc'),
-        sAe = q('sliderAe'),  sP  = q('sliderPasadas'),
-        infoP = q('textPasadasInfo'),  errBox = q('errorMsg');
+  const sVc = ready,
+        sFz = q('sliderFz'),
+        sAe = q('sliderAe'),
+        sP  = q('sliderPasadas'),
+        infoP = q('textPasadasInfo'),
+        errBox = q('errorMsg');
+
+  if (!sFz || !sVc || !sAe || !sP || !infoP || !errBox) {
+    console.error('[step6] elementos críticos del DOM faltantes');
+    return;
+  }
 
   const out = {
     vc : q('outVc'), fz : q('outFz'), hm : q('outHm'),
@@ -30,6 +49,11 @@ export function init () {
     mmr: q('valueMrr'), fc : q('valueFc'), w : q('valueW'),
     eta: q('valueEta'), ae : q('outAe'),   ap : q('outAp')
   };
+
+  if (Object.values(out).some(e => !e)) {
+    console.error('[step6] elementos de salida faltantes');
+    return;
+  }
 
   const UI = {
     show (m){ errBox.textContent = m; errBox.style.display = 'block'; },

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -823,7 +823,16 @@ safeScript(
 
 <!-- Script principal del paso 6  -->
 
-
+<script type="module"
+        src="<?= asset('assets/js/step6.js') ?>"
+        defer
+        onload="console.info('[step6] script cargado')"
+        onerror="console.error('[step6] error al cargar script')"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    window.step6?.init?.();
+  });
+</script>
 
 <script>
 /*-- Feather.replace() seguro: reintenta 10× cada 120 ms --*/


### PR DESCRIPTION
## Summary
- check for DOM ready in `step6.js`
- load `step6.js` as a module with `defer` in `views/steps/step6.php`
- call `step6.init()` on `DOMContentLoaded`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb2e395e8832cab3cf12e6aae0c87