### PR TITLE
Improve Step6 module loader

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -6,13 +6,17 @@
 ----------------------------------------------------------------*/
 
 export function init () {
-  const ready = document.getElementById('sliderVc');
-  if (!ready) {
+  const ids = [
+    'sliderVc','sliderFz','sliderAe','sliderPasadas',
+    'textPasadasInfo','errorMsg'
+  ];
+  const els = ids.map(id => document.getElementById(id));
+  if (els.some(el => !el)) {
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', init, { once: true });
       console.info('[step6] esperando DOMContentLoaded');
     } else {
-      console.warn('[step6] #sliderVc no encontrado');
+      console.warn('[step6] elementos necesarios no encontrados');
     }
     return;
   }
@@ -31,17 +35,7 @@ export function init () {
   /* ---------------- 2. DOM helpers ---------------- */
   const q = id => document.getElementById(id);
 
-  const sVc = ready,
-        sFz = q('sliderFz'),
-        sAe = q('sliderAe'),
-        sP  = q('sliderPasadas'),
-        infoP = q('textPasadasInfo'),
-        errBox = q('errorMsg');
-
-  if (!sFz || !sVc || !sAe || !sP || !infoP || !errBox) {
-    console.error('[step6] elementos críticos del DOM faltantes');
-    return;
-  }
+  const [sVc, sFz, sAe, sP, infoP, errBox] = els;
 
   const out = {
     vc : q('outVc'), fz : q('outFz'), hm : q('outHm'),

--- a/step6.php
+++ b/step6.php
@@ -263,13 +263,12 @@ window.addEventListener('error', e => {
   console.error('unhandled error', e.error || e.message);
 });
 </script>
-<script src="assets/js/step6.js"></script>
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    if (window.initStep6) {
-      window.initStep6();
-    }
-  });
+<script 
+  type="module" 
+  defer 
+  src="assets/js/step6.js"
+  onload="console.info('[step6] module loaded 👍'); window.step6?.init?.();"
+  onerror="console.error('❌ step6.js failed to load');">
 </script>
 </body>
 </html>

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -823,15 +823,12 @@ safeScript(
 
 <!-- Script principal del paso 6  -->
 
-<script type="module"
-        src="<?= asset('assets/js/step6.js') ?>"
-        defer
-        onload="console.info('[step6] script cargado')"
-        onerror="console.error('[step6] error al cargar script')"></script>
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    window.step6?.init?.();
-  });
+<script 
+  type="module" 
+  defer 
+  src="<?= asset('assets/js/step6.js') ?>"
+  onload="console.info('[step6] module loaded 👍'); window.step6?.init?.();"
+  onerror="console.error('❌ step6.js failed to load');">
 </script>
 
 <script>


### PR DESCRIPTION
## Summary
- guard init against missing DOM and re-attach to DOMContentLoaded
- load the module via type="module" with onload init in views/steps/step6.php
- update standalone step6.php with same loader snippet

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb716923c832cae44b6d0b21f8271