### PR TITLE
Add missing-id logging in step6 init

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -11,12 +11,13 @@ export function init () {
     'textPasadasInfo','errorMsg'
   ];
   const els = ids.map(id => document.getElementById(id));
-  if (els.some(el => !el)) {
+  const missing = ids.filter((_, i) => !els[i]);
+  if (missing.length) {
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', init, { once: true });
       console.info('[step6] esperando DOMContentLoaded');
     } else {
-      console.warn('[step6] elementos necesarios no encontrados');
+      console.warn('[step6] faltan elementos:', missing.join(', '));
     }
     return;
   }


### PR DESCRIPTION
## Summary
- improve `init` to list missing DOM elements

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f0451adcc832c9c5013a52331dc4f