### PR TITLE
Implement unified respondError helper

### DIFF
--- a/public/load-step.php
+++ b/public/load-step.php
@@ -60,15 +60,20 @@ if ($DEBUG && is_readable(ROOT_DIR . '/includes/debug.php')) {
 /* ───────────────────────────────────────────────────────────── */
 /* 5. RESPONDER CON ERROR                                        */
 /* ───────────────────────────────────────────────────────────── */
-function respondError(int $code, string $msg): never {
+function respondError(int $code, string $msg): void
+{
     http_response_code($code);
-    if (str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json')) {
+    $isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH'])
+        && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+
+    if ($isAjax) {
         header('Content-Type: application/json; charset=UTF-8');
         echo json_encode(['error' => $msg], JSON_UNESCAPED_UNICODE);
     } else {
-        echo '<div class="step-error alert alert-danger m-3">' .
-             htmlspecialchars($msg, ENT_QUOTES, 'UTF-8') .
-             '</div>';
+        echo '<!DOCTYPE html><html><body>'
+            . '<p>'
+            . htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')
+            . '</p></body></html>';
     }
     exit;
 }

--- a/step6.php
+++ b/step6.php
@@ -1,14 +1,19 @@
 <?php
 
-function respondError(int $code, string $msg): never {
+function respondError(int $code, string $msg): void
+{
     http_response_code($code);
-    if (str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json')) {
+    $isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH'])
+        && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+
+    if ($isAjax) {
         header('Content-Type: application/json; charset=UTF-8');
         echo json_encode(['error' => $msg], JSON_UNESCAPED_UNICODE);
     } else {
-        echo '<div class="step-error alert alert-danger m-3">' .
-             htmlspecialchars($msg, ENT_QUOTES, 'UTF-8') .
-             '</div>';
+        echo '<!DOCTYPE html><html><body>'
+            . '<p>'
+            . htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')
+            . '</p></body></html>';
     }
     exit;
 }

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -8,6 +8,24 @@
  */
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+
+function respondError(int $code, string $msg): void
+{
+    http_response_code($code);
+    $isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+        strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+
+    if ($isAjax) {
+        header('Content-Type: application/json; charset=UTF-8');
+        echo json_encode(['error' => $msg], JSON_UNESCAPED_UNICODE);
+    } else {
+        echo '<!DOCTYPE html><html><body>'
+            . '<p>'
+            . htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')
+            . '</p></body></html>';
+    }
+    exit;
+}
 /**
  * File: step3.php
  * ------------------------------------------------------------------

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -8,6 +8,24 @@
  */
 declare(strict_types=1);
 require_once __DIR__ . '/../../../src/Utils/Session.php';
+
+function respondError(int $code, string $msg): void
+{
+    http_response_code($code);
+    $isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+        strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+
+    if ($isAjax) {
+        header('Content-Type: application/json; charset=UTF-8');
+        echo json_encode(['error' => $msg], JSON_UNESCAPED_UNICODE);
+    } else {
+        echo '<!DOCTYPE html><html><body>'
+            . '<p>'
+            . htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')
+            . '</p></body></html>';
+    }
+    exit;
+}
 /**
  * File: views/steps/manual/step4.php
  * Paso 4 (Manual) – Selección de madera compatible

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -6,6 +6,27 @@
 
 declare(strict_types=1);
 
+/**
+ * Helper para devolver errores en AJAX o HTML simple
+ */
+function respondError(int $code, string $msg): void
+{
+    http_response_code($code);
+    $isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+        strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+
+    if ($isAjax) {
+        header('Content-Type: application/json; charset=UTF-8');
+        echo json_encode(['error' => $msg], JSON_UNESCAPED_UNICODE);
+    } else {
+        echo '<!DOCTYPE html><html><body>'
+            . '<p>'
+            . htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')
+            . '</p></body></html>';
+    }
+    exit;
+}
+
 set_exception_handler(function(Throwable $e){
     error_log('[step6][EXCEPTION] '.$e->getMessage()."\n".$e->getTraceAsString());
     http_response_code(500);


### PR DESCRIPTION
## Summary
- add `respondError()` helper to handle HTTP codes and AJAX JSON output
- use new helper in load-step.php and step6.php
- define the helper in wizard step view scripts

## Testing
- `composer install --no-interaction` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f04524f30832caac3f000081c3b2f