### PR TITLE
Define respondError helper in step views

### DIFF
--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -7,6 +7,22 @@
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
+
+if (!function_exists('respondError')) {
+    function respondError(int $code, string $msg): void {
+        http_response_code($code);
+        if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+            $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest') {
+            header('Content-Type: application/json');
+            echo json_encode(['error' => $msg], JSON_UNESCAPED_UNICODE);
+        } else {
+            header('Content-Type: text/html; charset=UTF-8');
+            echo '<p>' . htmlspecialchars($msg, ENT_QUOTES, 'UTF-8') . '</p>';
+        }
+        exit;
+    }
+}
+
 require_once __DIR__ . '/../../../src/Utils/Session.php';
 /**
  * File: step3.php

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -7,6 +7,22 @@
  * @TODO Extend documentation.
  */
 declare(strict_types=1);
+
+if (!function_exists('respondError')) {
+    function respondError(int $code, string $msg): void {
+        http_response_code($code);
+        if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+            $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest') {
+            header('Content-Type: application/json');
+            echo json_encode(['error' => $msg], JSON_UNESCAPED_UNICODE);
+        } else {
+            header('Content-Type: text/html; charset=UTF-8');
+            echo '<p>' . htmlspecialchars($msg, ENT_QUOTES, 'UTF-8') . '</p>';
+        }
+        exit;
+    }
+}
+
 require_once __DIR__ . '/../../../src/Utils/Session.php';
 /**
  * File: views/steps/manual/step4.php

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -6,6 +6,21 @@
 
 declare(strict_types=1);
 
+if (!function_exists('respondError')) {
+    function respondError(int $code, string $msg): void {
+        http_response_code($code);
+        if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+            $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest') {
+            header('Content-Type: application/json');
+            echo json_encode(['error' => $msg], JSON_UNESCAPED_UNICODE);
+        } else {
+            header('Content-Type: text/html; charset=UTF-8');
+            echo '<p>' . htmlspecialchars($msg, ENT_QUOTES, 'UTF-8') . '</p>';
+        }
+        exit;
+    }
+}
+
 set_exception_handler(function(Throwable $e){
     error_log('[step6][EXCEPTION] '.$e->getMessage()."\n".$e->getTraceAsString());
     http_response_code(500);


### PR DESCRIPTION
## Summary
- add a `respondError()` helper to `step6.php`
- define the helper for manual step3 and step4 views

## Testing
- `npm test` *(fails: Missing script)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f04524f30832caac3f000081c3b2f