### PR TITLE
Fix stepper position

### DIFF
--- a/assets/css/components/main.css
+++ b/assets/css/components/main.css
@@ -24,6 +24,8 @@ body {
 body {
   display: flex;
   flex-direction: column;
+  /* leave space for the fixed stepper */
+  padding-top: var(--stepper-offset, 70px);
 }
 
 .wizard-body {

--- a/assets/css/objects/stepper.css
+++ b/assets/css/objects/stepper.css
@@ -7,9 +7,12 @@ cooregime solo eso y damelo entero
  * TODO: Extend documentation.
  */
 .stepper-header {
-  position: sticky;
+  /* fixed to remain visible at the very top */
+  position: fixed;
   z-index: 1050;
   top: 0;
+  left: 0;
+  right: 0;
 
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- keep the stepper fixed at the top of the screen
- add body padding so content does not hide behind the stepper

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: style issues)*
- `composer run-script lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2d20a8ac832c9d56a254f26157a5