### PR TITLE
Fix stepper spacing

### DIFF
--- a/assets/css/components/main.css
+++ b/assets/css/components/main.css
@@ -24,8 +24,8 @@ body {
 body {
   display: flex;
   flex-direction: column;
-  /* leave space for the fixed stepper */
-  padding-top: var(--stepper-offset, 70px);
+  /* stepper should sit flush with the top */
+  padding-top: 0;
 }
 
 .wizard-body {


### PR DESCRIPTION
## Summary
- tweak main layout so the stepper stays flush with the top

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f33c65fec832c97d6f0467202d66a