### PR TITLE
fix sticky stepper

### DIFF
--- a/assets/css/components/main.css
+++ b/assets/css/components/main.css
@@ -24,8 +24,8 @@ body {
 body {
   display: flex;
   flex-direction: column;
-  /* stepper should sit flush with the top */
-  padding-top: 0;
+  /* leave space for the sticky stepper */
+  padding-top: 3.5rem;
 }
 
 .wizard-body {

--- a/assets/css/objects/stepper.css
+++ b/assets/css/objects/stepper.css
@@ -7,8 +7,9 @@ cooregime solo eso y damelo entero
  * TODO: Extend documentation.
  */
 .stepper-header {
-  /* fixed to remain visible at the very top */
-  position: fixed;
+  /* sticky so it remains visible at the top on any scroll context */
+  position: sticky;
+  position: -webkit-sticky;
   z-index: 1050;
   top: 0;
   left: 0;


### PR DESCRIPTION
## Summary
- keep wizard stepper visible with CSS `position: sticky`
- add top padding to body so content doesn't hide under the header

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4af737dc832ca1b60a24eb2337ee