### PR TITLE
Fix floating reset button

### DIFF
--- a/assets/css/objects/wizard.css
+++ b/assets/css/objects/wizard.css
@@ -297,5 +297,12 @@ body{
   }
 }
 
-.reset-wrap{ padding:.5rem 1rem; text-align:right; }
+.reset-wrap{
+  padding:.5rem 1rem;
+  text-align:right;
+  position:fixed;
+  top:1rem;
+  right:1rem;
+  z-index:1100;
+}
 


### PR DESCRIPTION
## Summary
- make the "Volver al inicio" button stay fixed in the upper-right corner

## Testing
- `./vendor/bin/phpunit` *(fails: file not found)*
- `npm run lint` *(fails: missing script)*
- `composer run-script lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f63408d60832ca4aeb09118d704ce