### PR TITLE
Implement smooth scrolling across wizard steps

### DIFF
--- a/views/steps/auto/step1.php
+++ b/views/steps/auto/step1.php
@@ -322,6 +322,9 @@ dbg('children', $children);
   const noMatch  = document.getElementById('no-match-msg');
   const dropdown = document.getElementById('searchDropdown');
 
+  /* Scroll suave a un elemento (si existe) */
+  function smoothTo(el){ if(el) el.scrollIntoView({behavior:'smooth',block:'start'}); }
+
   //────────────────────────────────────────────────────────────────────
   // Mapa material_id → parent_id
   const matToPid = {};
@@ -345,11 +348,9 @@ dbg('children', $children);
   }
 
   function validate() {
-    if (matInp.value && parseFloat(thick.value) > 0) {
-      nextContainer.style.display = 'block';
-    } else {
-      nextContainer.style.display = 'none';
-    }
+    const ok = matInp.value && parseFloat(thick.value) > 0;
+    nextContainer.style.display = ok ? 'block' : 'none';
+    if (ok) smoothTo(nextContainer);
   }
 
   function noMatchMsg(state) {
@@ -444,11 +445,13 @@ dbg('children', $children);
           thickGrp.style.display = 'block';
           validate();
           hideDropdown();
+          smoothTo(thickGrp);
         };
         matCol.appendChild(b);
       });
 
       matBox.style.display = 'block';
+      smoothTo(matBox);
       hideDropdown();
     };
   });

--- a/views/steps/auto/step2.php
+++ b/views/steps/auto/step2.php
@@ -293,6 +293,9 @@ const inType    = document.getElementById('machining_type_id');
 const inStrat   = document.getElementById('strategy_id');
 const nextBox   = document.getElementById('nextContainer');
 
+/* Scroll suave a un elemento (si existe) */
+function smoothTo(el){ if(el) el.scrollIntoView({behavior:'smooth',block:'start'}); }
+
 /* Reset estrategias */
 const resetStrategies = () => {
   stratBtns.innerHTML = '';
@@ -315,10 +318,12 @@ const renderStrategies = tid => {
       b.classList.add('active');
       inStrat.value = s.id;
       nextBox.style.display = 'block';
+      smoothTo(nextBox);
     };
     stratBtns.appendChild(b);
   });
   stratBox.style.display = 'block';
+  smoothTo(stratBox);
 };
 
 /* Click en tipo de mecanizado */

--- a/views/steps/manual/step3.php
+++ b/views/steps/manual/step3.php
@@ -287,6 +287,9 @@ const inputMt  = document.getElementById('machining_type_id');
 const inputSt  = document.getElementById('strategy_id');
 const nextBox  = document.getElementById('nextContainer');
 
+/* Scroll suave a un elemento (si existe) */
+function smoothTo(el){ if(el) el.scrollIntoView({behavior:'smooth',block:'start'}); }
+
 /* Helpers debug */
 window.dbg = (...m)=>{ console.log('[DBG]',...m);
   const d=document.getElementById('debug'); if(d) d.textContent+=m.join(' ')+'\n';};
@@ -304,10 +307,11 @@ machRow.querySelectorAll('.btn-machining').forEach(b=>{
       sb.type='button'; sb.className='btn btn-outline-secondary btn-strategy me-2 mb-2';
       sb.dataset.id=e.id; sb.textContent=e.name;
       sb.onclick=()=>{stratBtns.querySelectorAll('.btn-strategy').forEach(x=>x.classList.remove('active'));
-                      sb.classList.add('active'); inputSt.value=e.id; nextBox.style.display='block';};
+                      sb.classList.add('active'); inputSt.value=e.id; nextBox.style.display='block'; smoothTo(nextBox);};
       stratBtns.appendChild(sb);
     });
     stratBox.style.display='block';
+    smoothTo(stratBox);
   });
 });
 

--- a/views/steps/manual/step4.php
+++ b/views/steps/manual/step4.php
@@ -248,6 +248,9 @@ const search=document.getElementById('matSearch');
 const noMatch=document.getElementById('no-match-msg');
 const dropdown=document.getElementById('searchDropdown');
 
+/* Scroll suave a un elemento (si existe) */
+function smoothTo(el){ if(el) el.scrollIntoView({behavior:'smooth',block:'start'}); }
+
 const matToPid={};
 Object.entries(children).forEach(([pid,list])=>list.forEach(m=>matToPid[m.id]=pid));
 
@@ -256,7 +259,11 @@ function resetMat(){
   matInp.value='';thick.value='';thickGrp.style.display='none';
   nextCont.style.display='none';search.classList.remove('is-invalid');noMatch.style.display='none';
 }
-function validate(){ nextCont.style.display=(matInp.value && parseFloat(thick.value)>0)?'block':'none';}
+function validate(){
+  const ok = matInp.value && parseFloat(thick.value)>0;
+  nextCont.style.display = ok?'block':'none';
+  if(ok) smoothTo(nextCont);
+}
 function noMatchMsg(st){search.classList.toggle('is-invalid',st);noMatch.style.display=st?'block':'none';}
 function hideDD(){dropdown.style.display='none';dropdown.innerHTML='';}
 function showDropdown(list){
@@ -291,11 +298,15 @@ document.querySelectorAll('.btn-cat').forEach(btn=>{
         document.querySelectorAll('.btn-mat').forEach(x=>x.classList.remove('active'));
         b.classList.add('active');
         matInp.value=m.id;search.value=m.name;noMatchMsg(false);
-        thickGrp.style.display='block';validate();hideDD();
+        thickGrp.style.display='block';
+        validate();
+        hideDD();
+        smoothTo(thickGrp);
       });
       matCol.appendChild(b);
     });
     matBox.style.display='block';
+    smoothTo(matBox);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `smoothTo` helper in material and strategy steps
- scroll to materials, thickness, and next button in material steps
- scroll to strategies and next button in strategy steps

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm run lint` *(fails: Missing script)*
- `npm run lint:css` *(fails: stylelint not found)*
- `composer run-script lint` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606c1b0498832c88b03f2754987861