### PR TITLE
Add auto-scroll to top on step change

### DIFF
--- a/assets/js/wizard_stepper.js
+++ b/assets/js/wizard_stepper.js
@@ -131,6 +131,7 @@ const renderBar = current => {
         stepHolder.style.opacity = '1';
         renderBar(step);
         hookEvents();
+        window.scrollTo({ top: 0, behavior: 'smooth' });
         window.initLazy?.();
         dbgMsg(`🧭 Paso ${step} cargado correctamente`);
       })


### PR DESCRIPTION
## Summary
- ensure wizard scrolls to the top every time a new step is loaded

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run lint:css` *(fails: stylelint not found)*
- `composer run-script lint` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686075bc19ec832ca081c58055909303