### PR TITLE
Enable smooth scrolling in transmission step

### DIFF
--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -204,6 +204,9 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
     hp      : document.getElementById('hp')
   };
 
+  /* Scroll suave a un elemento (si existe) */
+  function smoothTo(el){ if(el) el.scrollIntoView({behavior:'smooth',block:'start'}); }
+
   /* Ocultar todo hasta elegir transmisión */
   const hideParams = () => {
     paramSec.style.display = 'none';
@@ -222,6 +225,7 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
 
     Object.values(inputs).forEach(i => i.disabled=false);
     paramSec.style.display = 'block';
+    smoothTo(paramSec);
     validate();
   }));
 
@@ -247,6 +251,7 @@ $hasPrev = (int)$prev['transmission_id'] > 0;
     }
 
     nextWrap.style.display = ok ? 'block' : 'none';
+    if (ok) smoothTo(nextWrap);
     return ok;
   }
 


### PR DESCRIPTION
## Summary
- add smoothTo helper in step5
- scroll to parameter fields when picking a transmission
- scroll to Next button when all fields are valid

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm run lint` *(fails: Missing script lint)*
- `composer run-script lint` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686075a2782c832cae35907832f08c56