### PR TITLE
Improve step transitions with fade effect

### DIFF
--- a/assets/css/components/main.css
+++ b/assets/css/components/main.css
@@ -31,3 +31,13 @@ body {
 .wizard-body {
   flex: 1 0 auto;
 }
+
+/* Smooth fade transition for step content */
+#step-content {
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+#step-content.show {
+  opacity: 1;
+}

--- a/assets/js/wizard_stepper.js
+++ b/assets/js/wizard_stepper.js
@@ -109,7 +109,7 @@ const renderBar = current => {
       return;
     }
 
-    stepHolder.style.opacity = '.3';
+    stepHolder.classList.remove('show');
     fetch(`${LOAD_ENDPOINT}?step=${step}${DEBUG ? '&debug=1' : ''}`, { cache: 'no-store' })
       .then(r => {
         if (r.status === 403) throw new Error('FORBIDDEN');
@@ -122,13 +122,12 @@ const renderBar = current => {
 
         requestAnimationFrame(() => {
           if (window.feather) feather.replace();
+          stepHolder.classList.add('show');
         });
 
         if (window.bootstrap && bootstrap.Tooltip) {
           document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
         }
-
-        stepHolder.style.opacity = '1';
         renderBar(step);
         hookEvents();
         window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -139,6 +138,7 @@ const renderBar = current => {
         error('Error loadStep', err);
         dbgMsg(err.message);
         stepHolder.innerHTML = `<div class="alert alert-danger">⚠️ Error cargando el paso ${step}: ${err.message}</div>`;
+        stepHolder.classList.add('show');
         if (err.message === 'FORBIDDEN') {
           localStorage.removeItem(LS_KEY);
           dbgMsg('⚠️ Sesión desfasada. Reinicio.');


### PR DESCRIPTION
## Summary
- add fading styles for wizard step content
- toggle CSS class in wizard_stepper.js to animate transitions

## Testing
- `vendor/bin/phpunit`
- `npm run lint:css` *(fails: stylelint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68607a2a4284832c89af67bfee731c09