### PR TITLE
Fix trans_id missing after step 5

### DIFF
--- a/views/steps/step5.php
+++ b/views/steps/step5.php
@@ -92,7 +92,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Guardar y avanzar si OK
     if (empty($errors)) {
+        // Guardar también alias trans_id para el paso 6
         $_SESSION['transmission_id'] = $id;
+        $_SESSION['trans_id']        = $id;
         $_SESSION['rpm_min']         = $rpmn;
         $_SESSION['rpm_max']         = $rpmm;
         $_SESSION['feed_max']        = $feed;


### PR DESCRIPTION
## Summary
- ensure step 5 stores `trans_id` in the session so step 6 has it

## Testing
- `vendor/bin/phpunit --stop-on-failure --configuration phpunit.xml` *(fails: No such file or directory)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628cae2804832ca36491b49a4b0256