### PR TITLE
Fix ramp feed dynamic calc

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -124,8 +124,9 @@
   const recalc = () => {
     const N      = rpm(state.vc);
     const vfRaw  = feed(N,state.fz);
-    const vf     = Math.min(vfRaw,FR_MAX);
-    const vfRamp = vf / Z;
+    const vf     = Math.min(vfRaw, FR_MAX);
+    const vfDisp = Math.round(vf);   // mismo valor que se muestra en resultados
+    const vfRamp = vfDisp / Z;
 
     /* Si feedrate topa, corregir fz visualmente para reflejar límite */
     if (vfRaw > FR_MAX) state.fz = FR_MAX/(N*Z);


### PR DESCRIPTION
## Summary
- compute ramp feed from the displayed feedrate in step6.js

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c2a28404832c9daa9ba913bd36a5