### PR TITLE
Add inline validation messages for step6

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -236,6 +236,8 @@ if (!$toolData) {
 
 try {
     $params = ExpertResultController::getResultData($pdo, $_SESSION);
+    // Largo de corte agregado a los parámetros para validaciones JS
+    $params['cut_length'] = $toolData['cut_length_mm'] ?? 0;
 } catch (\Throwable $e) {
     respondError(200, 'Error al generar datos de corte.');
 }
@@ -496,6 +498,7 @@ foreach ($styles as [$local, $cdn]) {
         <div class="result-box text-center flex-fill">
           <div class="param-label">Feedrate </div> <span class="param-explain">(Velocidad de avance)</span>
           <div><span id="outVf" class="fw-bold display-6"><?= $outVf ?></span> <span class="param-unit">mm/min</span></div>
+          <div id="feedAlert" class="alert alert-danger d-none mt-2"></div>
         </div>
         <div class="result-box text-center flex-fill">
           <div class="param-label">Velocidad del Rotacion </div> <span class="param-explain">(Revoluciones por minuto)</span>
@@ -557,6 +560,7 @@ foreach ($styles as [$local, $cdn]) {
           <div class="d-flex justify-content-center mb-4">
             <canvas id="radarChart" width="300" height="300"></canvas>
           </div>
+          <div id="rpmAlert" class="alert alert-danger d-none"></div>
           <?php if ($notesArray): ?>
             <ul class="notes-list mb-0">
               <?php foreach ($notesArray as $note): ?>
@@ -650,15 +654,16 @@ foreach ($styles as [$local, $cdn]) {
               </div>
             </div>
 
-            <div class="config-item">
-              <div class="label-static">Longitud total:</div>
-              <div class="value-static">
-                <?= number_format($fullLenMb,3,'.','') ?> <span class="param-unit">mm</span>
-              </div>
+          <div class="config-item">
+            <div class="label-static">Longitud total:</div>
+            <div class="value-static">
+              <?= number_format($fullLenMb,3,'.','') ?> <span class="param-unit">mm</span>
             </div>
           </div>
+        </div>
+        <div id="lenAlert" class="alert alert-danger d-none mt-2"></div>
 
-          <div class="section-divider"></div>
+        <div class="section-divider"></div>
 
           <!-- ===== Composición ===== -->
           <div class="config-section">


### PR DESCRIPTION
## Summary
- inject tool cut length into JS params
- add feedrate, rpm, and length alert containers in the step 6 view
- update step6.js to validate feedrate, rpm and cut length

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cb3eef30832cbee531556e8c7f84