### PR TITLE
Fix step6 params script load order

### DIFF
--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -777,17 +777,10 @@ foreach ($styles as [$local, $cdn]) {
 </div><!-- /.cards-grid -->
 
 
+
 </div><!-- .content-main -->
 
-<script 
-  type="module" 
-  defer 
-  src="<?= asset('assets/js/step6.js') ?>"
-  onload="console.info('[step6] module loaded 👍'); window.step6?.init?.();"
-  onerror="console.error('❌ step6.js failed to load');">
-</script>
-
-<!-- ========== SCRIPTS (blindados) ========== -->
+<!-- ========== Configuración paso 6 ========== -->
 <script>
   /*-- Parámetros técnicos + CSRF (100 % seguro) --*/
   window.step6Params = <?= json_encode(
@@ -799,6 +792,16 @@ foreach ($styles as [$local, $cdn]) {
   window.step6Csrf   = <?= json_encode($csrfToken, JSON_HEX_TAG) ?>;
   window.step6AjaxUrl = <?= json_encode(asset('ajax/step6_ajax_legacy_minimal.php'), JSON_HEX_TAG) ?>;
 </script>
+
+<script
+  type="module"
+  defer
+  src="<?= asset('assets/js/step6.js') ?>"
+  onload="console.info('[step6] module loaded 👍'); window.step6?.init?.();"
+  onerror="console.error('❌ step6.js failed to load');">
+</script>
+
+<!-- ========== SCRIPTS (blindados) ========== -->
 
 <?php if (!$embedded): ?>
 


### PR DESCRIPTION
## Summary
- ensure configuration script is executed before the main module on step 6

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68633b47b78c832c978ebac182d5f129