### PR TITLE
Compact alerts in step6

### DIFF
--- a/assets/css/components/_step6.css
+++ b/assets/css/components/_step6.css
@@ -126,6 +126,9 @@
 .notes-list li{ display:flex; gap:.5rem; align-items:flex-start; padding:.25rem 0; }
 .notes-list li i{ margin-top:.2rem; font-size:1rem; color:var(--step6-accent); }
 
+/* Compact alerts for step 6 */
+.alert-compact{ padding:.25rem .5rem; margin-bottom:.5rem; font-size:.875rem; }
+
 /* --------------------------------------------------------------------------
    9) Spinner
    --------------------------------------------------------------------------*/

--- a/assets/css/objects/step6.css
+++ b/assets/css/objects/step6.css
@@ -202,6 +202,9 @@ input.form-range:focus-visible::-moz-range-thumb {
 .notes-list li i { margin-top: 0.2rem; font-size: 1rem; color: var(--step6-accent); }
 .notes-list li div { font-size: 0.9rem; color: var(--step6-text-sec); }
 
+/* Compact alerts for step 6 */
+.alert-compact { padding: 0.25rem 0.5rem; margin-bottom: 0.5rem; font-size: 0.875rem; }
+
 /* helper Bootstrap */
 .text-secondary  { color: var(--step6-text-sec) !important; }
 

--- a/views/steps/step6.php
+++ b/views/steps/step6.php
@@ -498,7 +498,7 @@ foreach ($styles as [$local, $cdn]) {
         <div class="result-box text-center flex-fill">
           <div class="param-label">Feedrate </div> <span class="param-explain">(Velocidad de avance)</span>
           <div><span id="outVf" class="fw-bold display-6"><?= $outVf ?></span> <span class="param-unit">mm/min</span></div>
-          <div id="feedAlert" class="alert alert-danger d-none mt-2"></div>
+          <div id="feedAlert" class="alert alert-danger alert-compact d-none mt-2"></div>
         </div>
         <div class="result-box text-center flex-fill">
           <div class="param-label">Velocidad del Rotacion </div> <span class="param-explain">(Revoluciones por minuto)</span>
@@ -562,7 +562,7 @@ foreach ($styles as [$local, $cdn]) {
           <div class="d-flex justify-content-center mb-4">
             <canvas id="radarChart" width="300" height="300"></canvas>
           </div>
-          <div id="rpmAlert" class="alert alert-danger d-none"></div>
+          <div id="rpmAlert" class="alert alert-danger alert-compact d-none"></div>
           <?php if ($notesArray): ?>
             <ul class="notes-list mb-0">
               <?php foreach ($notesArray as $note): ?>
@@ -663,7 +663,7 @@ foreach ($styles as [$local, $cdn]) {
             </div>
           </div>
         </div>
-        <div id="lenAlert" class="alert alert-danger d-none mt-2"></div>
+        <div id="lenAlert" class="alert alert-danger alert-compact d-none mt-2"></div>
 
         <div class="section-divider"></div>
 


### PR DESCRIPTION
## Summary
- shrink alert spacing with a new `.alert-compact` style
- apply compact style to feed, rpm and length alerts in step6

## Testing
- `npm run lint:css --silent` *(fails: many pre-existing stylelint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686349480480832c8a1ffa36e9c8646a