### PR TITLE
Fix Step6 rpm limits

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -225,9 +225,13 @@
 
   /* ───────────────────── INIT ─────────────────── */
   try {
-    /* Limitar VC: ±50 % del valor base */
-    const vcMin = VC0 * 0.5;
-    const vcMax = VC0 * 1.5;
+    /* Limitar VC: ±50 % del valor base, dentro de RPM_MIN/MAX */
+    const vcBaseMin = VC0 * 0.5;
+    const vcBaseMax = VC0 * 1.5;
+    const vcFromRpm = rpm => (rpm * Math.PI * D) / 1000;
+    const vcMin = Math.max(vcBaseMin, vcFromRpm(RPM_MIN));
+    const vcMax = Math.min(vcBaseMax, vcFromRpm(RPM_MAX));
+    state.vc = Math.max(vcMin, Math.min(state.vc, vcMax));
     SL.vc.min = fmt(vcMin,1); SL.vc.max = fmt(vcMax,1); SL.vc.value = fmt(state.vc,1);
 
     SL.pass.value=1;                // por defecto 1 pasada


### PR DESCRIPTION
## Summary
- ensure VC slider doesn't exceed RPM bounds in step 6

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634bff98d8832c942fd566f68e6077