### PR TITLE
Update step6 slider limits

### DIFF
--- a/assets/js/step6.js
+++ b/assets/js/step6.js
@@ -316,6 +316,24 @@
     makeRadar();
     syncPass();
     recalc();
+
+    // Actualiza visualización de límites del slider fz
+    (() => {
+      const group = SL.fz?.closest('.mb-4');
+      if (!group) return;
+      const fzMinSpan = group.querySelector('span:nth-child(1)');
+      const fzMidVal  = group.querySelector('#valFz');
+      const fzMaxSpan = group.querySelector('span:last-child');
+
+      const fzMin  = fmt(FZ_MIN * K_SEG_transmission, 4);
+      const fzBase = fmt(FZ0 * K_SEG_transmission, 4);
+      const fzMax  = fmt(FZ_MAX * K_SEG_transmission, 4);
+
+      if (fzMinSpan) fzMinSpan.textContent = fzMin;
+      if (fzMidVal)  fzMidVal.textContent  = fzBase;
+      if (fzMaxSpan) fzMaxSpan.textContent = fzMax;
+    })();
+
     log('Init completo');
   } catch(e) {
     error(e);


### PR DESCRIPTION
## Summary
- update JS to refresh fz slider limit labels after applying safety factor

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e4d2ad94832caa671f72fc383fb1