### PR TITLE
Auto load selected series in admin

### DIFF
--- a/ADMIN/admin/series_edit.php
+++ b/ADMIN/admin/series_edit.php
@@ -150,6 +150,13 @@ $('#addTool').on('click', function(){
   const alt = ($('#geoBody tr').length/2)%2===1;
   $('#geoBody').append( geoRow({tool_id:id}, alt) );
 });
+
+// carga inicial si hay una serie seleccionada
+$(function(){
+  if ($('#seriesSel').val()) {
+    $('#seriesSel').trigger('change');
+  }
+});
 </script>
 
 <?php include __DIR__.'/../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- trigger series AJAX load if a series is preselected when opening the admin page

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `vendor/bin/phpunit` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864a7ca2324832ca2632e1299f93147