### PR TITLE
Admin series brand filter

### DIFF
--- a/admin/panel/series_ajax.php
+++ b/admin/panel/series_ajax.php
@@ -24,6 +24,7 @@ if (!$serie = $serie->fetch(PDO::FETCH_ASSOC)) {
   echo json_encode(['tools' => [], 'params' => []]);
   exit;
 }
+$brandId = (int)$serie['brand_id'];
 
 $toolTbl = brandTable($serie['brand_id']);
 $matTbl = 'toolsmaterial_' . substr($toolTbl, 6);
@@ -61,4 +62,8 @@ foreach ($pm as $r) {
   ];
 }
 
-echo json_encode(['tools' => $tools, 'params' => $params], JSON_UNESCAPED_UNICODE);
+echo json_encode([
+  'brand_id' => $brandId,
+  'tools'    => $tools,
+  'params'   => $params
+], JSON_UNESCAPED_UNICODE);

--- a/admin/panel/series_edit.php
+++ b/admin/panel/series_edit.php
@@ -42,7 +42,7 @@ $seriesId = $_GET['id'] ?? '';
       <div class="row g-3">
         <div class="col-md-3">
           <label class="form-label">Marca</label>
-          <select name="brand_id" class="form-select" required>
+          <select id="brandSel" name="brand_id" class="form-select" required>
             <?php foreach($brands as $b): ?>
               <option value="<?= $b['id'] ?>"><?= htmlspecialchars($b['name']) ?></option>
             <?php endforeach; ?>
@@ -124,6 +124,18 @@ function geoRow(t, alt) {
     <tr class="${rowClass}">${stratHTML}</tr>`;
 }
 
+function loadSeries(brandId, selected){
+  $('#seriesSel').html('<option value="">-- elige serie --</option>');
+  if(!brandId) return;
+  $.getJSON('api_series.php', { brand_id: brandId }, function(list){
+    list.forEach(s => {
+      const opt = $('<option>').val(s.id).text(s.code);
+      if(selected && selected==s.id) opt.prop('selected', true);
+      $('#seriesSel').append(opt);
+    });
+  });
+}
+
 // al cambiar serie, pido el JSON y dibujo filas
 $('#seriesSel').on('change', function(){
   const sid = $(this).val();
@@ -131,10 +143,25 @@ $('#seriesSel').on('change', function(){
   $('#geoBody').empty();
   if (!sid) return;
   $.getJSON('series_ajax.php', { series_id: sid }, function(res){
+    $('#brandSel').val(res.brand_id);
+    loadSeries(res.brand_id, sid);
     (res.tools||[]).forEach((t,i)=> {
       $('#geoBody').append( geoRow(t, i%2===1) );
     });
   });
+});
+
+// cambio de marca => cargar series
+$('#brandSel').on('change', function(){
+  loadSeries(this.value);
+  $('#seriesSel').val('');
+  $('#geoBody').empty();
+});
+
+$(function(){
+  const sid = $('#seriesSel').val();
+  if(sid){ $('#seriesSel').trigger('change'); }
+  else    { loadSeries($('#brandSel').val()); }
 });
 
 // botón de borrar fila


### PR DESCRIPTION
## Summary
- return `brand_id` in series AJAX endpoint
- filter series by brand on the series edit page
- auto-load tools when selecting a series

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `npm run lint:css` *(fails: stylelint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68652062b8bc832c93e6c7e859542a7c