### PR TITLE
Enable series search in admin

### DIFF
--- a/admin/panel/tools.php
+++ b/admin/panel/tools.php
@@ -185,7 +185,7 @@ function renderTable(){
             </a>
           </td>
           <td><span class="badge bg-info text-dark">${t.brand}</span></td>
-          <td>${t.series_id}</td>
+          <td>${t.series_code}</td>
           <td>${t.details.image?`<img src="../panel/${t.details.image}" class="thumb">`:''}</td>
           <td>${t.tool_code}</td>
           <td class="text-truncate" style="max-width:220px">${t.name}</td>

--- a/admin/panel/tools_ajax.php
+++ b/admin/panel/tools_ajax.php
@@ -49,8 +49,10 @@ foreach(['series_id','diameter_mm','shank_diameter_mm','flute_length_mm',
 }
 
 if($qText!==''){
-   $where[]="(U.name LIKE ? OR U.tool_code LIKE ?)";
-   $bind[]="%{$qText}%"; $bind[]="%{$qText}%";
+   $where[]="(U.name LIKE ? OR U.tool_code LIKE ? OR s.code LIKE ?)";
+   $bind[]="%{$qText}%"; 
+   $bind[]="%{$qText}%"; 
+   $bind[]="%{$qText}%";
 }
 
 /* --- 5) Material mecanizable --- */
@@ -81,7 +83,7 @@ if(!empty($f['strategy_id'])){
 }
 
 /* --- 7) SQL final --- */
-$sql="SELECT * FROM (\n$baseSql\n) AS U";
+$sql="SELECT U.*, s.code AS series_code FROM (\n$baseSql\n) AS U\n            LEFT JOIN series s ON s.id = U.series_id";
 if($where) $sql.="\nWHERE ".implode("\n  AND ",$where);
 $sql.="\nORDER BY U.tool_id DESC";
 


### PR DESCRIPTION
## Summary
- add database join to fetch `series_code` in `tools_ajax.php`
- include series code in search filtering
- show the human-readable series code in the admin tools table

## Testing
- `npm run lint:css` *(fails: 239 errors)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654a62f7e8832cb227e7577309bb72