### PR TITLE
Fix brandTable redeclaration causing AJAX error

### DIFF
--- a/admin/panel/series_ajax.php
+++ b/admin/panel/series_ajax.php
@@ -9,13 +9,15 @@ if (!$seriesId) {
   exit;
 }
 
-function brandTable(int $b): string {
-  return match($b) {
-    1 => 'tools_sgs',
-    2 => 'tools_maykestag',
-    3 => 'tools_schneider',
-    default => 'tools_generico',
-  };
+if (!function_exists('brandTable')) {
+  function brandTable(int $b): string {
+    return match($b) {
+      1 => 'tools_sgs',
+      2 => 'tools_maykestag',
+      3 => 'tools_schneider',
+      default => 'tools_generico',
+    };
+  }
 }
 
 $serie = $pdo->prepare("SELECT brand_id FROM series WHERE id=?");

--- a/admin/panel/series_save.php
+++ b/admin/panel/series_save.php
@@ -3,8 +3,10 @@ require_once __DIR__.'/../includes/db.php';
 require_once __DIR__.'/../includes/auth.php';
 header('Content-Type: application/json; charset=utf-8');
 
-function brandTable(int $b):string{
-  return match($b){1=>'tools_sgs',2=>'tools_maykestag',3=>'tools_schneider',default=>'tools_generico'};
+if (!function_exists('brandTable')) {
+  function brandTable(int $b):string{
+    return match($b){1=>'tools_sgs',2=>'tools_maykestag',3=>'tools_schneider',default=>'tools_generico'};
+  }
 }
 function matTable(string $t):string{ return 'toolsmaterial_'.substr($t,6); }
 


### PR DESCRIPTION
## Summary
- avoid fatal errors in `series_ajax.php` and `series_save.php` by guarding `brandTable` definition

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686575519d08832caa69f96127c203fc