### PR TITLE
Fix series admin save & add material

### DIFF
--- a/admin/panel/series_edit.php
+++ b/admin/panel/series_edit.php
@@ -78,6 +78,7 @@ $seriesId = $_GET['id'] ?? '';
 const catalogStrats = <?= json_encode(array_column($strats,'name','strategy_id')) ?>;
 const materials = <?= json_encode(array_column($mats,'name','material_id')) ?>;
 let counter = 0;
+let matCounter = 0;
 
 // genera una fila + la de estrategias debajo
 function geoRow(t, alt) {
@@ -220,6 +221,54 @@ $(document).on('click', '.delTool', function(){
   const tr = $(this).closest('tr');
   tr.next('tr').remove();
   tr.remove();
+});
+
+// guardar serie y parámetros
+$('#saveBtn').on('click', function(e){
+  e.preventDefault();
+  const $btn = $(this).prop('disabled', true);
+  $.post('series_save.php', $('#seriesForm').serialize(), function(res){
+    if(res.success){
+      alert('Datos guardados');
+    }else{
+      alert('Error: '+ (res.error || ''));}
+  }, 'json').fail(function(){
+    alert('Error de conexión');
+  }).always(function(){ $btn.prop('disabled', false); });
+});
+
+// agregar bloque de material vacío
+$('#addMat').on('click', function(){
+  const mid = 'new_' + (++matCounter);
+  const opts = Object.entries(materials)
+    .map(([id,name]) => `<option value="${id}">${name}</option>`).join('');
+  const ratingSel = [1,2,3].map(i=>`<option value="${i}">${i}</option>`).join('');
+  const cols = ['vc','fz_min','fz_max','ap','ae'];
+  const hdr = ['Vc','Fz min','Fz max','ap','ae'];
+  let rows = '';
+  $('#geoBody tr[data-tid]').each(function(){
+    const tid = $(this).data('tid');
+    const dia = $(this).find('input[name$="[diameter_mm]"]').val() || '';
+    rows += `<tr><td>${dia}</td>`+
+      cols.map(c=>`<td><input name="materials[${mid}][rows][${tid}][${c}]" class="form-control form-control-sm"></td>`).join('')+
+      `</tr>`;
+  });
+  $('#materialsWrap').append(`
+    <div class="mb-4 mat-block">
+      <div class="d-flex align-items-center mb-2">
+        <select name="materials[${mid}][material_id]" class="form-select me-2 w-auto">${opts}</select>
+        <select name="materials[${mid}][rating]" class="form-select form-select-sm w-auto me-2">${ratingSel}</select>
+        <button type="button" class="btn btn-outline-danger btn-sm delMat">✖</button>
+      </div>
+      <table class="table table-sm table-bordered">
+        <thead class="table-light"><tr><th>Ø</th>${hdr.map(h=>`<th>${h}</th>`).join('')}</tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>`);
+});
+
+$(document).on('click', '.delMat', function(){
+  $(this).closest('.mat-block').remove();
 });
 
 // agregar fresa vacía

--- a/admin/panel/series_save.php
+++ b/admin/panel/series_save.php
@@ -56,10 +56,12 @@ try{
   $pdo->prepare("DELETE pm FROM {$matTbl} pm JOIN {$toolTbl} t USING(tool_id)
                  WHERE t.series_id=?")->execute([$seriesId]);
   foreach($_POST['materials']??[] as $mid=>$d){
+    if(str_starts_with($mid,'new_'))
+      $mid = (int)($d['material_id'] ?? 0);
     $rating=(int)($d['rating']??0);
     foreach($d['rows']??[] as $tid=>$p){
       if(str_starts_with($tid,'new_')) $tid=$mapNew[$tid]??0;
-      if(!$tid) continue;
+      if(!$tid || !$mid) continue;
       $pdo->prepare("INSERT INTO {$matTbl}
         (tool_id,material_id,rating,vc_m_min,fz_min_mm,fz_max_mm,ap_slot_mm,ae_slot_mm)
         VALUES (?,?,?,?,?,?,?,?)")


### PR DESCRIPTION
## Summary
- enable saving a series from the admin panel
- allow adding material blocks dynamically
- support new material rows in series_save.php

## Testing
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_686712e12278832cb82b20cf6f2a290f