### PR TITLE
Hide tool strategies row

### DIFF
--- a/admin/panel/series_edit.php
+++ b/admin/panel/series_edit.php
@@ -16,6 +16,7 @@ $seriesId = $_GET['id'] ?? '';
   .sortable { cursor: pointer; }
   .table-wrap { overflow-x: auto; }
   tr.alt { background: #e9f3fb; }
+  tr.tool-strategies { display: none; }
 </style>
 
 <div class="container py-4">
@@ -117,7 +118,7 @@ function geoRow(t, alt) {
       <td><input name="${pre}[coated]" class="form-control" value="${t.coated||''}"></td>
       <td><button type="button" class="btn btn-sm btn-outline-danger delTool">✖</button></td>
     </tr>
-    <tr class="${rowClass}">${stratHTML}</tr>`;
+    <tr class="${rowClass} tool-strategies">${stratHTML}</tr>`;
 }
 
 function loadSeries(brandId, selected){


### PR DESCRIPTION
## Summary
- hide tool strategies row in series edit table

## Testing
- `vendor/bin/phpunit || phpunit`
- `npm run lint:css` *(fails: style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68673ae8c928832ca3598a7f4da37a8a