### PR TITLE
Improve admin series error handling

### DIFF
--- a/admin/includes/db.php
+++ b/admin/includes/db.php
@@ -27,7 +27,14 @@ function db(): PDO
             $pdo = new PDO($dsn, DB_USER, DB_PASS, $opts);
         } catch (PDOException $e) {
             http_response_code(500);
-            exit('DB Connection Error: ' . htmlspecialchars($e->getMessage()));
+            $msg = 'DB Connection Error: ' . $e->getMessage();
+            if (str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json')) {
+                header('Content-Type: application/json; charset=utf-8');
+                echo json_encode(['success' => false, 'error' => $msg]);
+            } else {
+                echo htmlspecialchars($msg);
+            }
+            exit;
         }
     }
     return $pdo;

--- a/admin/panel/series_edit.php
+++ b/admin/panel/series_edit.php
@@ -238,9 +238,14 @@ $('#saveBtn').on('click', function(e){
     if(res.success){
       alert('Datos guardados');
     }else{
-      alert('Error: '+ (res.error || ''));}
-  }, 'json').fail(function(){
-    alert('Error de conexión');
+      alert('Error: '+ (res.error || ''));
+    }
+  }, 'json').fail(function(jqXHR){
+    let msg = 'Error de conexión';
+    if(jqXHR.responseText){
+      msg += ': ' + jqXHR.responseText.trim();
+    }
+    alert(msg);
   }).always(function(){ $btn.prop('disabled', false); });
 });
 


### PR DESCRIPTION
## Summary
- show detailed DB connection errors in API responses
- display backend error message when saving a series fails

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_686740d663c0832c8d64e727742efc44