### PR TITLE
Fix null name error in step views

### DIFF
--- a/views/steps/auto/step4.php
+++ b/views/steps/auto/step4.php
@@ -189,7 +189,7 @@ if($tool){
         <?php endif; ?>
 
         <div class="card-body">
-          <h4><?= htmlspecialchars($tool['tool_code']) ?> – <?= htmlspecialchars($tool['name']) ?></h4>
+          <h4><?= htmlspecialchars($tool['tool_code']) ?> – <?= htmlspecialchars($tool['name'] ?? 'N/A') ?></h4>
           <p class="mb-1"><strong>Marca:</strong> <?= htmlspecialchars($tool['brand']) ?>
              &nbsp;|&nbsp; <strong>Serie:</strong> <?= htmlspecialchars($tool['serie']) ?></p>
           <p class="mb-1"><strong>Ø:</strong> <?= (float)$tool['diameter_mm'] ?> mm

--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -169,7 +169,7 @@ if ($tool) {
         <?php endif; ?>
         <div class="card-body">
           <div>
-            <h4><?= htmlspecialchars($tool['tool_code']) ?> – <?= htmlspecialchars($tool['name']) ?></h4>
+            <h4><?= htmlspecialchars($tool['tool_code']) ?> – <?= htmlspecialchars($tool['name'] ?? 'N/A') ?></h4>
             <p class="mb-1"><strong>Marca:</strong> <?= htmlspecialchars($tool['brand']) ?>
                &nbsp;|&nbsp; <strong>Serie:</strong> <?= htmlspecialchars($tool['serie']) ?></p>
             <p class="mb-1"><strong>Ø:</strong> <?= (float)$tool['diameter_mm'] ?> mm


### PR DESCRIPTION
## Summary
- avoid passing null to `htmlspecialchars` in manual and auto steps

## Testing
- `vendor/bin/phpunit`
- `npm run lint:css` *(fails: stylelint not satisfied)*

------
https://chatgpt.com/codex/tasks/task_e_68693c8d8030832c983c820621865fe7