### PR TITLE
Fix null tool type display

### DIFF
--- a/views/steps/manual/step2.php
+++ b/views/steps/manual/step2.php
@@ -174,7 +174,7 @@ if ($tool) {
                &nbsp;|&nbsp; <strong>Serie:</strong> <?= htmlspecialchars($tool['serie']) ?></p>
             <p class="mb-1"><strong>Ø:</strong> <?= (float)$tool['diameter_mm'] ?> mm
                &nbsp;|&nbsp; <strong>Filos:</strong> <?= (int)$tool['flute_count'] ?></p>
-            <p class="mb-1"><strong>Tipo:</strong> <?= htmlspecialchars($tool['tool_type']) ?></p>
+            <p class="mb-1"><strong>Tipo:</strong> <?= htmlspecialchars($tool['tool_type'] ?? 'N/A') ?></p>
             <p class="mb-0"><strong>Long. corte:</strong> <?= (float)$tool['cut_length_mm'] ?> mm
                &nbsp;|&nbsp; <strong>Total:</strong> <?= (float)$tool['length_total_mm'] ?> mm</p>
           </div>


### PR DESCRIPTION
## Summary
- avoid crash when tool_type is null

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693f5029a8832c9ee4343122c227f5