### PR TITLE
Implement bulk edit by column for series

### DIFF
--- a/api/series/bulk-column.php
+++ b/api/series/bulk-column.php
@@ -1,0 +1,35 @@
+<?php
+// api/series/bulk-column.php
+require_once __DIR__.'/../../includes/db.php';
+header('Content-Type: application/json; charset=utf-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'error' => 'Método no permitido']);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$column = $data['column'] ?? '';
+$value  = $data['value'] ?? '';
+$seriesId = isset($data['series_id']) ? (int)$data['series_id'] : 0;
+
+$allowed = ['made_in','material','tool_type','coated'];
+if (!in_array($column, $allowed, true) || !$seriesId) {
+    echo json_encode(['success' => false, 'error' => 'Datos inválidos']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT brand_id FROM series WHERE id = ?');
+$stmt->execute([$seriesId]);
+$brandId = $stmt->fetchColumn();
+if (!$brandId) {
+    echo json_encode(['success' => false, 'error' => 'Serie no encontrada']);
+    exit;
+}
+
+$table = brandTable((int)$brandId);
+$sql = "UPDATE {$table} SET {$column} = :val WHERE series_id = :sid";
+$u = $pdo->prepare($sql);
+$ok = $u->execute([':val' => $value, ':sid' => $seriesId]);
+
+echo json_encode(['success' => $ok]);

--- a/assets/js/series_edit.js
+++ b/assets/js/series_edit.js
@@ -1,0 +1,42 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  const applyBtn=document.getElementById('bulkApply');
+  const columnSel=document.getElementById('bulkColumn');
+  const valueInput=document.getElementById('bulkValue');
+  const modalEl=document.getElementById('confirmBulkModal');
+  if(!applyBtn||!columnSel||!valueInput||!modalEl) return;
+  const modal=new bootstrap.Modal(modalEl);
+  const confirmInput=document.getElementById('confirmWord');
+  const finalBtn=document.getElementById('confirmBulkBtn');
+  if(confirmInput){
+    confirmInput.addEventListener('input',()=>{
+      finalBtn.disabled=confirmInput.value.trim().toUpperCase()!=='APLICAR';
+    });
+  }
+  applyBtn.addEventListener('click',()=>{
+    if(!confirm('¿Aplicar cambios a toda la tabla?')) return;
+    confirmInput.value='';
+    finalBtn.disabled=true;
+    modal.show();
+  });
+  finalBtn.addEventListener('click',async()=>{
+    modal.hide();
+    const seriesId=document.getElementById('seriesSel').value;
+    if(!seriesId) return alert('Serie no seleccionada');
+    const body={column:columnSel.value,value:valueInput.value,series_id:seriesId};
+    try{
+      const res=await fetch('../../api/series/bulk-column.php',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify(body)
+      });
+      const j=await res.json();
+      if(j.success){
+        fetchSeriesTools();
+      }else{
+        alert('Error: '+(j.error||''));
+      }
+    }catch(e){
+      alert('Error de conexión');
+    }
+  });
+});

--- a/src/Model/SeriesModel.php
+++ b/src/Model/SeriesModel.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Modelo SeriesModel: operaciones sobre series y sus herramientas.
+ */
+declare(strict_types=1);
+
+class SeriesModel
+{
+    /**
+     * Actualiza masivamente una columna permitida en todas las
+     * herramientas de la serie indicada.
+     *
+     * @param PDO    $pdo       Conexión a base de datos
+     * @param string $column    Columna a modificar
+     * @param mixed  $value     Nuevo valor
+     * @param int    $seriesId  ID de la serie
+     * @return bool             Éxito de la operación
+     */
+    public static function bulkColumn(PDO $pdo, string $column, $value, int $seriesId): bool
+    {
+        $allowed = ['made_in','material','tool_type','coated'];
+        if (!in_array($column, $allowed, true)) {
+            return false;
+        }
+
+        $stmt = $pdo->prepare('SELECT brand_id FROM series WHERE id = ?');
+        $stmt->execute([$seriesId]);
+        $brandId = $stmt->fetchColumn();
+        if (!$brandId) {
+            return false;
+        }
+        $table = brandTable((int)$brandId);
+        $sql = "UPDATE {$table} SET {$column} = :val WHERE series_id = :sid";
+        $u = $pdo->prepare($sql);
+        return $u->execute([':val' => $value, ':sid' => $seriesId]);
+    }
+}


### PR DESCRIPTION
## Summary
- extend series edit grid with name, tool type, notes and image fields
- allow mass edition via new bulk row and confirmation modal
- add JavaScript helpers for double confirmation and API call
- backend endpoint to update single column for all tools in a series
- new `SeriesModel` with `bulkColumn` method

## Testing
- `phpunit` *(fails: vendor binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_686942b42660832ca0e3a93ee7c7a84d