### PR TITLE
Allow editing materials without rating

### DIFF
--- a/admin/panel/series_ajax.php
+++ b/admin/panel/series_ajax.php
@@ -52,7 +52,7 @@ $pm = $pdo->prepare("SELECT tm.tool_id, tm.material_id, tm.rating,
          tm.vc_m_min, tm.fz_min_mm, tm.fz_max_mm, tm.ap_slot_mm, tm.ae_slot_mm
     FROM {$toolTbl} t
     JOIN {$matTbl} tm ON tm.tool_id = t.tool_id
-   WHERE t.series_id = ? AND tm.rating > 0");
+   WHERE t.series_id = ?");
 $pm->execute([$seriesId]);
 $params = [];
 foreach ($pm as $r) {

--- a/admin/panel/series_edit.php
+++ b/admin/panel/series_edit.php
@@ -246,7 +246,7 @@ function renderParams(params, tools){
         <label class="form-check-label">${name}</label>
       </div>`).join('');
   Object.entries(params).forEach(([mid, data]) => {
-    if(!data || data.rating <= 0) return;
+    if(!data) return;
     let rows = '';
     tools.forEach(t => {
       const r = data.rows && data.rows[t.tool_id] ? data.rows[t.tool_id] : {};


### PR DESCRIPTION
## Summary
- fetch material params regardless of rating
- show materials even with zero rating

## Testing
- `./vendor/bin/phpunit`
- `npm run lint` *(fails: Missing script)*
- `composer run-script lint` *(fails: script not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6869461b51b8832cb619ef6671b91df3